### PR TITLE
change okr-db restart from 'always' to 'unless stopped'

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   okr-db:
     container_name: okr-dev-db
     image: postgres:12
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pwd


### PR DESCRIPTION
Die DB wird bei jedem Restart wieder gestartet, sofern man die DB nicht vorher stoppt.