### PR TITLE
Feature/testdaten in measure form

### DIFF
--- a/frontend/src/app/keyresult/diagram/diagram.component.spec.ts
+++ b/frontend/src/app/keyresult/diagram/diagram.component.spec.ts
@@ -9,12 +9,13 @@ import {
 } from '../../shared/services/key-result.service';
 import * as measureData from '../../shared/testing/mock-data/measure.json';
 import * as goalData from '../../shared/testing/mock-data/goals.json';
+import { loadAllMeasure } from '../../shared/testing/Loader';
 
 describe('DiagramComponent', () => {
   let component: DiagramComponent;
   let fixture: ComponentFixture<DiagramComponent>;
 
-  let measures: Observable<Measure[]> = of(measureData.measures);
+  let measures: Observable<any[]> = of(loadAllMeasure(true));
 
   const mockKeyResultService = {
     getMeasuresOfKeyResult: jest.fn(),
@@ -76,7 +77,7 @@ describe('DiagramComponent', () => {
     measures.subscribe((item) => {
       diagrammObjects = component.generateDiagrammObjects(item);
     });
-    expect(diagrammObjects[1].x).toEqual('2023-01-21');
-    expect(diagrammObjects[2].x).toEqual('2023-03-18');
+    expect(diagrammObjects[1].x).toEqual('2022-12-23T01:00:00.000Z');
+    expect(diagrammObjects[2].x).toEqual('2023-01-05T01:00:00.000Z');
   });
 });

--- a/frontend/src/app/keyresult/diagram/diagram.component.spec.ts
+++ b/frontend/src/app/keyresult/diagram/diagram.component.spec.ts
@@ -77,7 +77,7 @@ describe('DiagramComponent', () => {
     measures.subscribe((item) => {
       diagrammObjects = component.generateDiagrammObjects(item);
     });
-    expect(diagrammObjects[1].x).toEqual('2022-12-23T01:00:00.000Z');
-    expect(diagrammObjects[2].x).toEqual('2023-01-05T01:00:00.000Z');
+    expect(diagrammObjects[1].x).toEqual('2022-12-23');
+    expect(diagrammObjects[2].x).toEqual('2023-01-05 01:00:00');
   });
 });

--- a/frontend/src/app/measure/measure-form/measure-form.component.spec.ts
+++ b/frontend/src/app/measure/measure-form/measure-form.component.spec.ts
@@ -15,8 +15,9 @@ import {
   KeyResultService,
 } from '../../shared/services/key-result.service';
 import * as keyresultData from '../../shared/testing/mock-data/keyresults.json';
+import * as measureData from '../../shared/testing/mock-data/measure.json';
 import { Observable, of } from 'rxjs';
-import { Measure, MeasureService } from '../../shared/services/measure.service';
+import { MeasureService } from '../../shared/services/measure.service';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { MatInputModule } from '@angular/material/input';
@@ -31,49 +32,35 @@ describe('MeasureFormComponent', () => {
 
   let keyResult: Observable<KeyResultMeasure> = of(keyresultData.keyresults[0]);
 
-  let initMeasure: Measure = {
-    id: null,
-    keyResultId: 1,
-    value: 0,
-    changeInfo: '',
-    initiatives: '',
-    createdBy: 0,
-    createdOn: new Date('2022-12-01'),
-    measureDate: new Date('2022-12-23'),
-  };
-
-  let measure1: Observable<Measure> = of({
-    id: 1,
-    keyResultId: 1,
-    value: 42,
-    changeInfo: 'Changeinfo',
-    initiatives: 'Initiatives',
-    createdBy: 1,
-    createdOn: new Date('2022-12-28'),
-    measureDate: new Date('2023-01-05 01:00:00'),
+  let initMeasure = Object.assign({}, measureData.initMeasure, {
+    createdOn: new Date(measureData.initMeasure.createdOn),
+    measureDate: new Date(measureData.initMeasure.measureDate),
   });
 
-  let receivedEditedMeasure: Measure = {
-    id: 1,
-    keyResultId: 1,
-    value: 30,
-    changeInfo: 'New Changeinfo',
-    initiatives: 'Initiatives',
-    createdBy: 1,
-    createdOn: new Date('2022-12-28T00:00:00.000Z'),
-    measureDate: new Date('2023-01-05T01:00:00.000Z'),
-  };
+  let measure1 = of(
+    Object.assign({}, measureData.measure, {
+      createdOn: new Date(measureData.measure.createdOn),
+      measureDate: new Date(measureData.measure.measureDate),
+    })
+  );
 
-  let receivedCreatedMeasure: Measure = {
-    id: null,
-    keyResultId: 1,
-    value: 33,
-    changeInfo: 'Changeinfo 1',
-    initiatives: 'Initiatives 1',
-    createdBy: 0,
-    createdOn: new Date('2022-12-01T00:00:00.000Z'),
-    measureDate: new Date('2022-12-01T00:00:00.000Z'),
-  };
+  let receivedEditedMeasure = Object.assign(
+    {},
+    measureData.receivedEditedMeasure,
+    {
+      createdOn: new Date(measureData.receivedEditedMeasure.createdOn),
+      measureDate: new Date(measureData.receivedEditedMeasure.measureDate),
+    }
+  );
+
+  let receivedCreatedMeasure = Object.assign(
+    {},
+    measureData.receivedCreatedMeasure,
+    {
+      createdOn: new Date(measureData.receivedCreatedMeasure.createdOn),
+      measureDate: new Date(measureData.receivedCreatedMeasure.measureDate),
+    }
+  );
 
   const mockGetNumerOrNull = {
     getNumberOrNull: jest.fn(),

--- a/frontend/src/app/measure/measure-form/measure-form.component.spec.ts
+++ b/frontend/src/app/measure/measure-form/measure-form.component.spec.ts
@@ -121,7 +121,9 @@ describe('MeasureFormComponent', () => {
       component.measure$.subscribe((measure) => {
         expect(measure.id).toEqual(1);
         expect(measure.value).toEqual(42);
-        expect(measure.measureDate).toEqual(new Date('2023-01-05'));
+        expect(measure.measureDate).toEqual(
+          new Date('2023-01-05T00:00:00.000Z')
+        );
 
         expect(component.measureForm.get('value')?.value).toEqual(33);
         expect(component.measureForm.get('measureDate')?.value).toEqual(

--- a/frontend/src/app/measure/measure-form/measure-form.component.spec.ts
+++ b/frontend/src/app/measure/measure-form/measure-form.component.spec.ts
@@ -25,6 +25,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { loadMeasure } from '../../shared/testing/Loader';
 
 describe('MeasureFormComponent', () => {
   let component: MeasureFormComponent;
@@ -32,35 +33,10 @@ describe('MeasureFormComponent', () => {
 
   let keyResult: Observable<KeyResultMeasure> = of(keyresultData.keyresults[0]);
 
-  let initMeasure = Object.assign({}, measureData.initMeasure, {
-    createdOn: new Date(measureData.initMeasure.createdOn),
-    measureDate: new Date(measureData.initMeasure.measureDate),
-  });
-
-  let measure1 = of(
-    Object.assign({}, measureData.measure, {
-      createdOn: new Date(measureData.measure.createdOn),
-      measureDate: new Date(measureData.measure.measureDate),
-    })
-  );
-
-  let receivedEditedMeasure = Object.assign(
-    {},
-    measureData.receivedEditedMeasure,
-    {
-      createdOn: new Date(measureData.receivedEditedMeasure.createdOn),
-      measureDate: new Date(measureData.receivedEditedMeasure.measureDate),
-    }
-  );
-
-  let receivedCreatedMeasure = Object.assign(
-    {},
-    measureData.receivedCreatedMeasure,
-    {
-      createdOn: new Date(measureData.receivedCreatedMeasure.createdOn),
-      measureDate: new Date(measureData.receivedCreatedMeasure.measureDate),
-    }
-  );
+  let initMeasure = loadMeasure('initMeasure');
+  let measure1 = of(loadMeasure('measure'));
+  let receivedEditedMeasure = loadMeasure('receivedEditedMeasure');
+  let receivedCreatedMeasure = loadMeasure('receivedCreatedMeasure');
 
   const mockGetNumerOrNull = {
     getNumberOrNull: jest.fn(),

--- a/frontend/src/app/shared/services/measure.service.spec.ts
+++ b/frontend/src/app/shared/services/measure.service.spec.ts
@@ -5,9 +5,9 @@ import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
-import * as measureData from '../testing/mock-data/measure.json';
+import { loadMeasure } from '../testing/Loader';
 
-const respons = measureData.measures[0];
+const respons = loadMeasure('measure');
 
 describe('MeasureService', () => {
   let service: MeasureService;

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -3,8 +3,25 @@ import * as measureData from './mock-data/measure.json';
 
 export function loadMeasure(name: string): Measure {
   let measureDataObject: any = measureData;
-  return Object.assign({}, measureDataObject[name], {
-    createdOn: new Date(measureDataObject[name].createdOn),
-    measureDate: new Date(measureDataObject[name].measureDate),
+  return overwriteObjectWithCorrectDate(measureDataObject[name]);
+}
+
+export function loadAllMeasure(loadWithString: boolean): any[] {
+  let measureDataObject: any = measureData;
+  let measureArray: any[] = [];
+  for (let prop in measureDataObject) {
+    if (loadWithString) {
+      measureArray.push(measureDataObject[prop]);
+      continue;
+    }
+    measureArray.push(overwriteObjectWithCorrectDate(measureDataObject[prop]));
+  }
+  return measureArray;
+}
+
+function overwriteObjectWithCorrectDate(measure: any): any {
+  return Object.assign({}, measure, {
+    createdOn: new Date(measure.createdOn),
+    measureDate: new Date(measure.measureDate),
   });
 }

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -1,0 +1,10 @@
+import { Measure } from '../services/measure.service';
+import * as measureData from './mock-data/measure.json';
+
+export function loadMeasure(name: string): Measure {
+  let measureDataObject: any = measureData;
+  return Object.assign({}, measureDataObject[name], {
+    createdOn: new Date(measureDataObject[name].createdOn),
+    measureDate: new Date(measureDataObject[name].measureDate),
+  });
+}

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -4,7 +4,11 @@ import * as measureData from './mock-data/measure.json';
 export function loadMeasure(name: string): Measure {
   let measureDataObject: any = measureData;
   return Object.assign({}, measureDataObject[name], {
-    createdOn: new Date(measureDataObject[name].createdOn),
-    measureDate: new Date(measureDataObject[name].measureDate),
+    createdOn: turnToIsoDate(new Date(measureDataObject[name].createdOn)),
+    measureDate: turnToIsoDate(new Date(measureDataObject[name].measureDate)),
   });
+}
+
+function turnToIsoDate(date: Date): Date {
+  return new Date(date.toISOString());
 }

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -4,7 +4,18 @@ import * as measureData from './mock-data/measure.json';
 export function loadMeasure(name: string): Measure {
   let measureDataObject: any = measureData;
   return Object.assign({}, measureDataObject[name], {
-    createdOn: new Date(measureDataObject[name].createdOn),
-    measureDate: new Date(measureDataObject[name].measureDate),
+    createdOn: turnToUTCDate(new Date(measureDataObject[name].createdOn)),
+    measureDate: turnToUTCDate(new Date(measureDataObject[name].measureDate)),
   });
+}
+
+function turnToUTCDate(date: Date): Date {
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
 }

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -4,18 +4,7 @@ import * as measureData from './mock-data/measure.json';
 export function loadMeasure(name: string): Measure {
   let measureDataObject: any = measureData;
   return Object.assign({}, measureDataObject[name], {
-    createdOn: turnToUTCDate(new Date(measureDataObject[name].createdOn)),
-    measureDate: turnToUTCDate(new Date(measureDataObject[name].measureDate)),
+    createdOn: new Date(measureDataObject[name].createdOn),
+    measureDate: new Date(measureDataObject[name].measureDate),
   });
-}
-
-function turnToUTCDate(date: Date): Date {
-  return new Date(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
-    date.getUTCHours(),
-    date.getUTCMinutes(),
-    date.getUTCSeconds()
-  );
 }

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -4,11 +4,7 @@ import * as measureData from './mock-data/measure.json';
 export function loadMeasure(name: string): Measure {
   let measureDataObject: any = measureData;
   return Object.assign({}, measureDataObject[name], {
-    createdOn: turnToIsoDate(new Date(measureDataObject[name].createdOn)),
-    measureDate: turnToIsoDate(new Date(measureDataObject[name].measureDate)),
+    createdOn: new Date(measureDataObject[name].createdOn),
+    measureDate: new Date(measureDataObject[name].measureDate),
   });
-}
-
-function turnToIsoDate(date: Date): Date {
-  return new Date(date.toISOString());
 }

--- a/frontend/src/app/shared/testing/Loader.ts
+++ b/frontend/src/app/shared/testing/Loader.ts
@@ -1,14 +1,18 @@
 import { Measure } from '../services/measure.service';
 import * as measureData from './mock-data/measure.json';
 
+type NameOfMeasure = {
+  [name: string]: Measure;
+};
+
+const measureDataObject: NameOfMeasure = measureData as any as NameOfMeasure;
+
 export function loadMeasure(name: string): Measure {
-  let measureDataObject: any = measureData;
   return overwriteObjectWithCorrectDate(measureDataObject[name]);
 }
 
-export function loadAllMeasure(loadWithString: boolean): any[] {
-  let measureDataObject: any = measureData;
-  let measureArray: any[] = [];
+export function loadAllMeasure(loadWithString: boolean): Measure[] {
+  let measureArray: Measure[] = [];
   for (let prop in measureDataObject) {
     if (loadWithString) {
       measureArray.push(measureDataObject[prop]);
@@ -19,7 +23,7 @@ export function loadAllMeasure(loadWithString: boolean): any[] {
   return measureArray;
 }
 
-function overwriteObjectWithCorrectDate(measure: any): any {
+function overwriteObjectWithCorrectDate(measure: Measure): Measure {
   return Object.assign({}, measure, {
     createdOn: new Date(measure.createdOn),
     measureDate: new Date(measure.measureDate),

--- a/frontend/src/app/shared/testing/mock-data/measure.json
+++ b/frontend/src/app/shared/testing/mock-data/measure.json
@@ -37,6 +37,6 @@
     "initiatives": "Initiatives 1",
     "createdBy": 0,
     "createdOn": "2022-12-01T00:00:00.000Z",
-    "measureDate": "2022-12-01T00:00:00.000Z"
+    "measureDate": "2022-12-01T01:00:00.000Z"
   }
 }

--- a/frontend/src/app/shared/testing/mock-data/measure.json
+++ b/frontend/src/app/shared/testing/mock-data/measure.json
@@ -1,34 +1,42 @@
 {
-  "measures": [
-    {
-      "id": 1,
-      "keyResultId": 1,
-      "value": 60,
-      "changeInfo": "Changeinfo 1",
-      "initiatives": "Initiatives 1",
-      "createdBy": 1,
-      "createdOn": "2023-01-18",
-      "measureDate": "2022-12-23"
-    },
-    {
-      "id": 2,
-      "keyResultId": 1,
-      "value": 40,
-      "changeInfo": "Changeinfo 2",
-      "initiatives": "Initiatives 2",
-      "createdBy": 1,
-      "createdOn": "2023-02-02",
-      "measureDate": "2023-03-18"
-    },
-    {
-      "id": 3,
-      "keyResultId": 1,
-      "value": 40,
-      "changeInfo": "Changeinfo 3",
-      "initiatives": "Initiatives 3",
-      "createdBy": 1,
-      "createdOn": "2023-02-02",
-      "measureDate": "2023-01-21"
-    }
-  ]
+  "initMeasure": {
+    "id": null,
+    "keyResultId": 1,
+    "value": 0,
+    "changeInfo": "",
+    "initiatives": "",
+    "createdBy": 0,
+    "createdOn": "2022-12-01T00:00:00.000Z",
+    "measureDate": "2022-12-23T01:00:00.000Z"
+  },
+  "measure": {
+    "id": 1,
+    "keyResultId": 1,
+    "value": 42,
+    "changeInfo": "Changeinfo",
+    "initiatives": "Initiatives",
+    "createdBy": 1,
+    "createdOn": "2022-12-28T00:00:00.000Z",
+    "measureDate": "2023-01-05T00:00:00.000Z"
+  },
+  "receivedEditedMeasure": {
+    "id": 1,
+    "keyResultId": 1,
+    "value": 30,
+    "changeInfo": "New Changeinfo",
+    "initiatives": "Initiatives",
+    "createdBy": 1,
+    "createdOn": "2022-12-28T00:00:00.000Z",
+    "measureDate": "2023-01-05T01:00:00.000Z"
+  },
+  "receivedCreatedMeasure": {
+    "id": null,
+    "keyResultId": 1,
+    "value": 33,
+    "changeInfo": "Changeinfo 1",
+    "initiatives": "Initiatives 1",
+    "createdBy": 0,
+    "createdOn": "2022-12-01T00:00:00.000Z",
+    "measureDate": "2022-12-01T00:00:00.000Z"
+  }
 }

--- a/frontend/src/app/shared/testing/mock-data/measure.json
+++ b/frontend/src/app/shared/testing/mock-data/measure.json
@@ -16,8 +16,8 @@
     "changeInfo": "Changeinfo",
     "initiatives": "Initiatives",
     "createdBy": 1,
-    "createdOn": "2022-12-28T00:00:00.000Z",
-    "measureDate": "2023-01-05T00:00:00.000Z"
+    "createdOn": "2022-12-28",
+    "measureDate": "2023-01-05 01:00:00"
   },
   "receivedEditedMeasure": {
     "id": 1,
@@ -37,6 +37,6 @@
     "initiatives": "Initiatives 1",
     "createdBy": 0,
     "createdOn": "2022-12-01T00:00:00.000Z",
-    "measureDate": "2022-12-01T01:00:00.000Z"
+    "measureDate": "2022-12-01T00:00:00.000Z"
   }
 }

--- a/frontend/src/app/shared/testing/mock-data/measure.json
+++ b/frontend/src/app/shared/testing/mock-data/measure.json
@@ -17,7 +17,7 @@
     "initiatives": "Initiatives",
     "createdBy": 1,
     "createdOn": "2022-12-28",
-    "measureDate": "2023-01-05 01:00:00"
+    "measureDate": "2023-01-05T01:00:00.000Z"
   },
   "receivedEditedMeasure": {
     "id": 1,
@@ -27,7 +27,7 @@
     "initiatives": "Initiatives",
     "createdBy": 1,
     "createdOn": "2022-12-28T00:00:00.000Z",
-    "measureDate": "2023-01-05T01:00:00.000Z"
+    "measureDate": "2023-01-05T02:00:00.000Z"
   },
   "receivedCreatedMeasure": {
     "id": null,

--- a/frontend/src/app/shared/testing/mock-data/measure.json
+++ b/frontend/src/app/shared/testing/mock-data/measure.json
@@ -6,8 +6,8 @@
     "changeInfo": "",
     "initiatives": "",
     "createdBy": 0,
-    "createdOn": "2022-12-01T00:00:00.000Z",
-    "measureDate": "2022-12-23T01:00:00.000Z"
+    "createdOn": "2022-12-01",
+    "measureDate": "2022-12-23"
   },
   "measure": {
     "id": 1,
@@ -17,7 +17,7 @@
     "initiatives": "Initiatives",
     "createdBy": 1,
     "createdOn": "2022-12-28",
-    "measureDate": "2023-01-05T01:00:00.000Z"
+    "measureDate": "2023-01-05 01:00:00"
   },
   "receivedEditedMeasure": {
     "id": 1,
@@ -27,7 +27,7 @@
     "initiatives": "Initiatives",
     "createdBy": 1,
     "createdOn": "2022-12-28T00:00:00.000Z",
-    "measureDate": "2023-01-05T02:00:00.000Z"
+    "measureDate": "2023-01-05T01:00:00.000Z"
   },
   "receivedCreatedMeasure": {
     "id": null,


### PR DESCRIPTION
Änderungen:
- Es wurde ein Loader gebaut, der 2 Funktionen exportiert: 
a) loadMeasure, welche den Namen des Measures als Parameter nimmt
b) loadAllMeasures, welche einen boolean "loadWithString" als Parameter nimmt. Dies musste implementiert
werden, da einige Tests die Date Values noch als String gebrauchen.

- Schlussendliche wurden die Testobjekte eins zu eins in ein JSON ausgelagert.