### PR TITLE
Feature/4 progress berechnen

### DIFF
--- a/backend/src/main/java/ch/puzzle/okr/controller/MeasureController.java
+++ b/backend/src/main/java/ch/puzzle/okr/controller/MeasureController.java
@@ -86,6 +86,8 @@ public class MeasureController {
             @ApiResponse(responseCode = "404", description = "Did not find the Measure with requested id") })
     @DeleteMapping("/{id}")
     public void deleteMeasureById(@PathVariable long id) {
+        Measure measure = this.measureService.getMeasureById(id);
+        this.progressService.updateObjectiveProgress(measure.getKeyResult().getObjective().getId());
         measureService.deleteMeasureById(id);
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/controller/ObjectiveController.java
+++ b/backend/src/main/java/ch/puzzle/okr/controller/ObjectiveController.java
@@ -76,8 +76,7 @@ public class ObjectiveController {
             @RequestBody ObjectiveDto objectiveDTO) {
         objectiveDTO.setId(id);
         Objective objective = this.objectiveMapper.toObjective(objectiveDTO);
-        ObjectiveDto updatedObjective = this.objectiveMapper
-                .toDto(this.objectiveService.updateObjective(id, objective));
+        ObjectiveDto updatedObjective = this.objectiveMapper.toDto(this.objectiveService.updateObjective(objective));
         return ResponseEntity.status(HttpStatus.OK).body(updatedObjective);
     }
 

--- a/backend/src/main/java/ch/puzzle/okr/dto/KeyResultDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/KeyResultDto.java
@@ -15,10 +15,11 @@ public class KeyResultDto {
     private Unit unit;
     private Long basicValue;
     private Long targetValue;
+    private Long progress;
 
     public KeyResultDto(Long id, Long objectiveId, String title, String description, Long ownerId,
             String ownerFirstname, String ownerLastname, ExpectedEvolution expectedEvolution, Unit unit,
-            Long basicValue, Long targetValue) {
+            Long basicValue, Long targetValue, Long progress) {
         this.id = id;
         this.objectiveId = objectiveId;
         this.title = title;
@@ -30,6 +31,7 @@ public class KeyResultDto {
         this.unit = unit;
         this.basicValue = basicValue;
         this.targetValue = targetValue;
+        this.progress = progress;
     }
 
     public Long getId() {
@@ -118,5 +120,13 @@ public class KeyResultDto {
 
     public void setTargetValue(Long targetValue) {
         this.targetValue = targetValue;
+    }
+
+    public Long getProgress() {
+        return progress;
+    }
+
+    public void setProgress(Long progress) {
+        this.progress = progress;
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/dto/KeyResultMeasureDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/KeyResultMeasureDto.java
@@ -16,10 +16,11 @@ public class KeyResultMeasureDto {
     private Long basicValue;
     private Long targetValue;
     private MeasureDto measure;
+    private Long progress;
 
     public KeyResultMeasureDto(Long id, Long objectiveId, String title, String description, Long ownerId,
             String ownerFirstname, String ownerLastname, ExpectedEvolution expectedEvolution, Unit unit,
-            Long basicValue, Long targetValue, MeasureDto measureDto) {
+            Long basicValue, Long targetValue, MeasureDto measureDto, Long progress) {
         this.id = id;
         this.objectiveId = objectiveId;
         this.title = title;
@@ -32,6 +33,7 @@ public class KeyResultMeasureDto {
         this.basicValue = basicValue;
         this.targetValue = targetValue;
         this.measure = measureDto;
+        this.progress = progress;
     }
 
     public Long getId() {
@@ -128,5 +130,13 @@ public class KeyResultMeasureDto {
 
     public void setMeasure(MeasureDto measure) {
         this.measure = measure;
+    }
+
+    public Long getProgress() {
+        return progress;
+    }
+
+    public void setProgress(Long progress) {
+        this.progress = progress;
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/helper/KeyResultMeasureValue.java
+++ b/backend/src/main/java/ch/puzzle/okr/helper/KeyResultMeasureValue.java
@@ -1,0 +1,9 @@
+package ch.puzzle.okr.helper;
+
+public interface KeyResultMeasureValue {
+    Integer getTargetValue();
+
+    Integer getBasisValue();
+
+    Integer getValue();
+}

--- a/backend/src/main/java/ch/puzzle/okr/helper/KeyResultMeasureValue.java
+++ b/backend/src/main/java/ch/puzzle/okr/helper/KeyResultMeasureValue.java
@@ -3,7 +3,13 @@ package ch.puzzle.okr.helper;
 public interface KeyResultMeasureValue {
     Integer getTargetValue();
 
+    void setTargetValue(Integer targetValue);
+
     Integer getBasisValue();
 
+    void setBasisValue(Integer basisValue);
+
     Integer getValue();
+
+    void setValue(Integer value);
 }

--- a/backend/src/main/java/ch/puzzle/okr/mapper/KeyResultMapper.java
+++ b/backend/src/main/java/ch/puzzle/okr/mapper/KeyResultMapper.java
@@ -4,6 +4,7 @@ import ch.puzzle.okr.dto.KeyResultDto;
 import ch.puzzle.okr.models.KeyResult;
 import ch.puzzle.okr.repository.UserRepository;
 import ch.puzzle.okr.service.KeyResultService;
+import ch.puzzle.okr.service.ProgressService;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -15,16 +16,21 @@ public class KeyResultMapper {
     // TODO: Remove UserRepository when Login works and use logged in user for createdBy in toKeyResult method
     private final UserRepository userRepository;
 
-    public KeyResultMapper(KeyResultService keyResultService, UserRepository userRepository) {
+    private final ProgressService progressService;
+
+    public KeyResultMapper(KeyResultService keyResultService, UserRepository userRepository,
+            ProgressService progressService) {
         this.keyResultService = keyResultService;
         this.userRepository = userRepository;
+        this.progressService = progressService;
     }
 
     public KeyResultDto toDto(KeyResult keyResult) {
         return new KeyResultDto(keyResult.getId(), keyResult.getObjective().getId(), keyResult.getTitle(),
                 keyResult.getDescription(), keyResult.getOwner().getId(), keyResult.getOwner().getFirstname(),
                 keyResult.getOwner().getLastname(), keyResult.getExpectedEvolution(), keyResult.getUnit(),
-                keyResult.getBasisValue(), keyResult.getTargetValue());
+                keyResult.getBasisValue(), keyResult.getTargetValue(),
+                progressService.updateKeyResultProgress(keyResult.getId()));
     }
 
     public KeyResult toKeyResult(KeyResultDto keyResultDto) {

--- a/backend/src/main/java/ch/puzzle/okr/mapper/KeyResultMeasureMapper.java
+++ b/backend/src/main/java/ch/puzzle/okr/mapper/KeyResultMeasureMapper.java
@@ -3,20 +3,24 @@ package ch.puzzle.okr.mapper;
 import ch.puzzle.okr.dto.KeyResultMeasureDto;
 import ch.puzzle.okr.models.KeyResult;
 import ch.puzzle.okr.models.Measure;
+import ch.puzzle.okr.service.ProgressService;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KeyResultMeasureMapper {
     private final MeasureMapper measureMapper;
+    private final ProgressService progressService;
 
-    public KeyResultMeasureMapper(MeasureMapper measureMapper) {
+    public KeyResultMeasureMapper(MeasureMapper measureMapper, ProgressService progressService) {
         this.measureMapper = measureMapper;
+        this.progressService = progressService;
     }
 
     public KeyResultMeasureDto toDto(KeyResult keyResult, Measure measure) {
         return new KeyResultMeasureDto(keyResult.getId(), keyResult.getObjective().getId(), keyResult.getTitle(),
                 keyResult.getDescription(), keyResult.getOwner().getId(), keyResult.getOwner().getFirstname(),
                 keyResult.getOwner().getLastname(), keyResult.getExpectedEvolution(), keyResult.getUnit(),
-                keyResult.getBasisValue(), keyResult.getTargetValue(), measureMapper.toDto(measure));
+                keyResult.getBasisValue(), keyResult.getTargetValue(), measureMapper.toDto(measure),
+                this.progressService.updateKeyResultProgress(keyResult.getId()));
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/models/Objective.java
+++ b/backend/src/main/java/ch/puzzle/okr/models/Objective.java
@@ -35,7 +35,6 @@ public class Objective {
     @Size(min = 2, max = 1024 * 4)
     private String description;
 
-    @NotNull
     private Long progress;
 
     @NotNull

--- a/backend/src/main/java/ch/puzzle/okr/repository/KeyResultRepository.java
+++ b/backend/src/main/java/ch/puzzle/okr/repository/KeyResultRepository.java
@@ -11,7 +11,6 @@ import java.util.List;
 public interface KeyResultRepository extends CrudRepository<KeyResult, Long> {
     List<KeyResult> findByObjective(@Param("objective") Objective objective);
 
-    // TODO: Check if keyresults has measures, if not return null
     @Query(value = "select k.target_value as targetValue, k.basis_value as basisValue, m.value as value from key_result as k, measure as m, (select max(measure_date) as measureDate, key_result_id from measure where key_result_id = :keyResultId group by key_result_id) as t where t.key_result_id = m.key_result_id and t.measureDate = m.measure_date and k.id = m.key_result_id", nativeQuery = true)
     KeyResultMeasureValue getProgressValuesKeyResult(@Param("keyResultId") Long keyResultId);
 }

--- a/backend/src/main/java/ch/puzzle/okr/repository/KeyResultRepository.java
+++ b/backend/src/main/java/ch/puzzle/okr/repository/KeyResultRepository.java
@@ -1,6 +1,8 @@
 package ch.puzzle.okr.repository;
 
+import ch.puzzle.okr.helper.KeyResultMeasureValue;
 import ch.puzzle.okr.models.*;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
@@ -8,4 +10,8 @@ import java.util.List;
 
 public interface KeyResultRepository extends CrudRepository<KeyResult, Long> {
     List<KeyResult> findByObjective(@Param("objective") Objective objective);
+
+    // TODO: Check if keyresults has measures, if not return null
+    @Query(value = "select k.target_value as targetValue, k.basis_value as basisValue, m.value as value from key_result as k, measure as m, (select max(measure_date) as measureDate, key_result_id from measure where key_result_id = :keyResultId group by key_result_id) as t where t.key_result_id = m.key_result_id and t.measureDate = m.measure_date and k.id = m.key_result_id", nativeQuery = true)
+    KeyResultMeasureValue getProgressValuesKeyResult(@Param("keyResultId") Long keyResultId);
 }

--- a/backend/src/main/java/ch/puzzle/okr/repository/ObjectiveRepository.java
+++ b/backend/src/main/java/ch/puzzle/okr/repository/ObjectiveRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Repository
 public interface ObjectiveRepository extends CrudRepository<Objective, Long> {
-    @Query(value = "select k.target_value as targetValue, k.basis_value as basisValue, m.value as value from key_result as k, measure as m, (select max(created_on) as created_on, key_result_id from measure group by key_result_id) as t where t.key_result_id = m.key_result_id and t.created_on = m.created_on and k.id = m.key_result_id and k.objective_id = :objective_id", nativeQuery = true)
+    @Query(value = "select k.target_value as targetValue, k.basis_value as basisValue, m.value as value from key_result as k, measure as m,(select max(measure_date) as measure_date, key_result_id from measure as m, key_result as k where k.objective_id = :objective_id and k.id = m.key_result_id group by key_result_id) as t where t.key_result_id = m.key_result_id and t.measure_date = m.measure_date and k.id = m.key_result_id and k.objective_id = :objective_id", nativeQuery = true)
     List<KeyResultMeasureValue> getCalculationValuesForProgress(@Param("objective_id") Long objectiveId);
 
     List<Objective> findByTeamId(long id);

--- a/backend/src/main/java/ch/puzzle/okr/repository/ObjectiveRepository.java
+++ b/backend/src/main/java/ch/puzzle/okr/repository/ObjectiveRepository.java
@@ -1,5 +1,6 @@
 package ch.puzzle.okr.repository;
 
+import ch.puzzle.okr.helper.KeyResultMeasureValue;
 import ch.puzzle.okr.models.Objective;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -10,10 +11,8 @@ import java.util.List;
 
 @Repository
 public interface ObjectiveRepository extends CrudRepository<Objective, Long> {
-
-    @Query(value = "select coalesce(AVG((CAST(m.value as decimal) / CAST((k.target_value - k.basis_value) as decimal))*100), 0)"
-            + "from key_result as k, measure as m, (select max(measure_date) as measure_date, key_result_id from measure group by key_result_id) as t where t.key_result_id = m.key_result_id and t.measure_date = m.measure_date and k.id = m.key_result_id and k.objective_id = :objective_id", nativeQuery = true)
-    Double getProgressOfObjective(@Param("objective_id") Long objectiveId);
+    @Query(value = "select k.target_value as targetValue, k.basis_value as basisValue, m.value as value from key_result as k, measure as m, (select max(created_on) as created_on, key_result_id from measure group by key_result_id) as t where t.key_result_id = m.key_result_id and t.created_on = m.created_on and k.id = m.key_result_id and k.objective_id = :objective_id", nativeQuery = true)
+    List<KeyResultMeasureValue> getCalculationValuesForProgress(@Param("objective_id") Long objectiveId);
 
     List<Objective> findByTeamId(long id);
 

--- a/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
@@ -21,7 +21,6 @@ public class KeyResultService {
     private final ObjectiveRepository objectiveRepository;
     private final MeasureRepository measureRepository;
     private final KeyResultMeasureMapper keyResultMeasureMapper;
-    private final ProgressService progressService;
 
     public KeyResultService(KeyResultRepository keyResultRepository, QuarterRepository quarterRepository,
             UserRepository userRepository, ObjectiveRepository objectiveRepository, MeasureRepository measureRepository,
@@ -32,7 +31,6 @@ public class KeyResultService {
         this.objectiveRepository = objectiveRepository;
         this.measureRepository = measureRepository;
         this.keyResultMeasureMapper = keyResultMeasureMapper;
-        this.progressService = progressService;
     }
 
     public List<KeyResult> getAllKeyResults() {

--- a/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
@@ -21,6 +21,7 @@ public class KeyResultService {
     private final ObjectiveRepository objectiveRepository;
     private final MeasureRepository measureRepository;
     private final KeyResultMeasureMapper keyResultMeasureMapper;
+    private final ProgressService progressService;
 
     public KeyResultService(KeyResultRepository keyResultRepository, QuarterRepository quarterRepository,
             UserRepository userRepository, ObjectiveRepository objectiveRepository, MeasureRepository measureRepository,
@@ -31,6 +32,7 @@ public class KeyResultService {
         this.objectiveRepository = objectiveRepository;
         this.measureRepository = measureRepository;
         this.keyResultMeasureMapper = keyResultMeasureMapper;
+        this.progressService = progressService;
     }
 
     public List<KeyResult> getAllKeyResults() {
@@ -99,6 +101,6 @@ public class KeyResultService {
             measureRepository.deleteById(measure.getId());
         }
         keyResultRepository.deleteById(id);
-        progressService.updateObjectiveProgress(objectiveId);
+        this.progressService.updateObjectiveProgress(objectiveId);
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
@@ -49,7 +49,7 @@ public class ObjectiveService {
         if (objective.getProgress() != null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Not allowed to give a progress");
         }
-        objective.setProgress(0L);
+        objective.setProgress(null);
         this.checkObjective(objective);
         return objectiveRepository.save(objective);
     }

--- a/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
@@ -54,16 +54,8 @@ public class ObjectiveService {
         return objectiveRepository.save(objective);
     }
 
-    public Objective updateObjective(Long id, Objective objective) {
-        if (objective.getProgress() != null) {
-            List<KeyResult> keyResultList = (List<KeyResult>) this.keyResultRepository.findAll();
-            if (keyResultList.stream()
-                    .anyMatch(keyResult -> keyResult.getObjective().getId().equals(objective.getId()))) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                        "Can't set the progress of an objective if you have already defined keyresults!");
-            }
-        }
-        Objective existingObjective = this.getObjective(id);
+    public Objective updateObjective(Objective objective) {
+        Objective existingObjective = this.getObjective(objective.getId());
         objective.setQuarter(existingObjective.getQuarter());
         objective.setProgress(existingObjective.getProgress());
         this.checkObjective(objective);

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -2,6 +2,7 @@ package ch.puzzle.okr.service;
 
 import ch.puzzle.okr.helper.KeyResultMeasureValue;
 import ch.puzzle.okr.models.Objective;
+import ch.puzzle.okr.repository.KeyResultRepository;
 import ch.puzzle.okr.repository.ObjectiveRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -13,10 +14,13 @@ import java.util.List;
 public class ProgressService {
     private final ObjectiveService objectiveService;
     private final ObjectiveRepository objectiveRepository;
+    private final KeyResultRepository keyResultRepository;
 
-    public ProgressService(ObjectiveService objectiveService, ObjectiveRepository objectiveRepository) {
+    public ProgressService(ObjectiveService objectiveService, ObjectiveRepository objectiveRepository,
+            KeyResultRepository keyResultRepository) {
         this.objectiveService = objectiveService;
         this.objectiveRepository = objectiveRepository;
+        this.keyResultRepository = keyResultRepository;
     }
 
     public void updateObjectiveProgress(Long objectiveId) {
@@ -25,6 +29,11 @@ public class ProgressService {
                 .calculateObjectiveProgress(this.objectiveRepository.getCalculationValuesForProgress(objectiveId));
         objective.setProgress(progress);
         this.objectiveRepository.save(objective);
+    }
+
+    public long updateKeyResultProgress(Long keyResultId) {
+        return (long) Math
+                .floor(returnCheckedProgress(this.keyResultRepository.getProgressValuesKeyResult(keyResultId)));
     }
 
     public long calculateObjectiveProgress(List<KeyResultMeasureValue> keyResultMeasureValues) {

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -63,12 +63,16 @@ public class ProgressService {
 
     protected double calculateKeyResultProgress(KeyResultMeasureValue keyResultMeasureValue) {
         if (keyResultMeasureValue.getBasisValue() > keyResultMeasureValue.getTargetValue()) {
-            return calculate(keyResultMeasureValue.getBasisValue().doubleValue(),
-                    keyResultMeasureValue.getTargetValue().doubleValue(),
+            return turnedCalculation(keyResultMeasureValue.getTargetValue().doubleValue(),
+                    keyResultMeasureValue.getBasisValue().doubleValue(),
                     keyResultMeasureValue.getValue().doubleValue());
         }
         return calculate(keyResultMeasureValue.getTargetValue().doubleValue(),
                 keyResultMeasureValue.getBasisValue().doubleValue(), keyResultMeasureValue.getValue().doubleValue());
+    }
+
+    public double turnedCalculation(double targetValue, double basisValue, double value) {
+        return basisValue == value ? 0 : (100 / ((basisValue - targetValue) / (basisValue - value)));
     }
 
     protected double calculate(double targetValue, double basisValue, double value) {

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -27,6 +27,9 @@ public class ProgressService {
         Objective objective = this.objectiveService.getObjective(objectiveId);
         Long progress = this
                 .calculateObjectiveProgress(this.objectiveRepository.getCalculationValuesForProgress(objectiveId));
+        if (progress == null && !this.keyResultRepository.findByObjective(objective).isEmpty()) {
+            progress = 0L;
+        }
         objective.setProgress(progress);
         this.objectiveRepository.save(objective);
     }
@@ -39,7 +42,10 @@ public class ProgressService {
         return null;
     }
 
-    public long calculateObjectiveProgress(List<KeyResultMeasureValue> keyResultMeasureValues) {
+    public Long calculateObjectiveProgress(List<KeyResultMeasureValue> keyResultMeasureValues) {
+        if (keyResultMeasureValues.isEmpty()) {
+            return null;
+        }
         return (long) Math.floor(keyResultMeasureValues.stream().mapToDouble(this::returnCheckedProgress).average()
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                         "Progress calculation failed!")));

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -31,9 +31,12 @@ public class ProgressService {
         this.objectiveRepository.save(objective);
     }
 
-    public long updateKeyResultProgress(Long keyResultId) {
-        return (long) Math
-                .floor(returnCheckedProgress(this.keyResultRepository.getProgressValuesKeyResult(keyResultId)));
+    public Long updateKeyResultProgress(Long keyResultId) {
+        KeyResultMeasureValue keyResultMeasureValue = this.keyResultRepository.getProgressValuesKeyResult(keyResultId);
+        if (keyResultMeasureValue != null) {
+            return (long) Math.floor(returnCheckedProgress(keyResultMeasureValue));
+        }
+        return null;
     }
 
     public long calculateObjectiveProgress(List<KeyResultMeasureValue> keyResultMeasureValues) {

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -1,8 +1,13 @@
 package ch.puzzle.okr.service;
 
+import ch.puzzle.okr.helper.KeyResultMeasureValue;
 import ch.puzzle.okr.models.Objective;
 import ch.puzzle.okr.repository.ObjectiveRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 @Service
 public class ProgressService {
@@ -16,8 +21,39 @@ public class ProgressService {
 
     public void updateObjectiveProgress(Long objectiveId) {
         Objective objective = this.objectiveService.getObjective(objectiveId);
-        Long progress = Math.round(this.objectiveRepository.getProgressOfObjective(objective.getId()));
+        Long progress = this
+                .calculateObjectiveProgress(this.objectiveRepository.getCalculationValuesForProgress(objectiveId));
         objective.setProgress(progress);
         this.objectiveRepository.save(objective);
+    }
+
+    public long calculateObjectiveProgress(List<KeyResultMeasureValue> keyResultMeasureValues) {
+        return (long) Math.floor(keyResultMeasureValues.stream().mapToDouble(this::returnCheckedProgress).average()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                        "Progress calculation failed!")));
+    }
+
+    public double returnCheckedProgress(KeyResultMeasureValue keyResultMeasureValue) {
+        double percentValue = this.calculateKeyResultProgress(keyResultMeasureValue);
+        if (percentValue > 100) {
+            return 100;
+        } else if (percentValue < 0) {
+            return 0;
+        }
+        return percentValue;
+    }
+
+    private double calculateKeyResultProgress(KeyResultMeasureValue keyResultMeasureValue) {
+        if (keyResultMeasureValue.getBasisValue() > keyResultMeasureValue.getTargetValue()) {
+            return calculate(keyResultMeasureValue.getBasisValue().doubleValue(),
+                    keyResultMeasureValue.getTargetValue().doubleValue(),
+                    keyResultMeasureValue.getValue().doubleValue());
+        }
+        return calculate(keyResultMeasureValue.getTargetValue().doubleValue(),
+                keyResultMeasureValue.getBasisValue().doubleValue(), keyResultMeasureValue.getValue().doubleValue());
+    }
+
+    private double calculate(double targetValue, double basisValue, double value) {
+        return basisValue == value ? 0 : (100 / ((targetValue - basisValue) / (value - basisValue)));
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -61,7 +61,7 @@ public class ProgressService {
         return percentValue;
     }
 
-    private double calculateKeyResultProgress(KeyResultMeasureValue keyResultMeasureValue) {
+    protected double calculateKeyResultProgress(KeyResultMeasureValue keyResultMeasureValue) {
         if (keyResultMeasureValue.getBasisValue() > keyResultMeasureValue.getTargetValue()) {
             return calculate(keyResultMeasureValue.getBasisValue().doubleValue(),
                     keyResultMeasureValue.getTargetValue().doubleValue(),
@@ -71,7 +71,7 @@ public class ProgressService {
                 keyResultMeasureValue.getBasisValue().doubleValue(), keyResultMeasureValue.getValue().doubleValue());
     }
 
-    private double calculate(double targetValue, double basisValue, double value) {
+    protected double calculate(double targetValue, double basisValue, double value) {
         return basisValue == value ? 0 : (100 / ((targetValue - basisValue) / (value - basisValue)));
     }
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -24,7 +24,7 @@ insert into quarter(id, label) values
 
 --  quartal GJ 22/23-Q1 (1.7.2022 - 30.9.2022)
 insert into objective(id, title, owner_id, team_id, quarter_id, progress, created_on, description) values
-        (1, 'Motivierte und glückliche Members', 1, 1, 3, '61', '2022-07-01', 'Puzzle ITC will motivierte und glückliche Members.'),
+        (1, 'Motivierte und glückliche Members', 1, 1, 3, '57', '2022-07-01', 'Puzzle ITC will motivierte und glückliche Members.'),
         (2, 'Objective 2', 2, 2, 3, '0', '2019-01-01', 'This is the description of Objective 2'),
         (3, 'Objective 3', 4, 3, 3, '0', '2020-01-01', 'This is the description of Objective 3');
 
@@ -44,7 +44,7 @@ insert into measure(id, key_result_id, measure_date, value, created_by_id, creat
 
 --  quartal GJ 22/23-Q2 (1.10.2022 - 31.12.2022)
 insert into objective(id, title, owner_id, team_id, quarter_id, progress, created_on, description) values
-        (4, 'Motivierte und glückliche Members', 1, 1, 2, '61', '2022-10-01', 'Puzzle ITC will motivierte und glückliche Members.');
+        (4, 'Motivierte und glückliche Members', 1, 1, 2, '80', '2022-10-01', 'Puzzle ITC will motivierte und glückliche Members.');
 
 insert into key_result(id, objective_id, owner_id, expected_evolution, unit, basis_value, target_value, created_by_id, created_on, title, description) values
         (7, 4, 5, 1, 2, 0, 4, 1, '2022-10-01', 'Reichlich Schokolade', 'Auf allen drei Stockwerke sollten 4 verschiedene Schokoladenarten angeboten werden.'),
@@ -62,7 +62,7 @@ insert into measure(id, key_result_id, measure_date, value, created_by_id, creat
 
 --  quartal GJ 22/23-Q3 (1.1.2023 - 31.3.2023)
 insert into objective(id, title, owner_id, team_id, quarter_id, progress, created_on, description) values
-        (5, 'Motivierte und glückliche Members', 1, 1, 1, '61', '2023-01-01', 'Puzzle ITC will motivierte und glückliche Members.');
+        (5, 'Motivierte und glückliche Members', 1, 1, 1, '73', '2023-01-01', 'Puzzle ITC will motivierte und glückliche Members.');
 
 insert into key_result(id, objective_id, owner_id, expected_evolution, unit, basis_value, target_value, created_by_id, created_on, title, description) values
         (11, 5, 5, 1, 2, 0, 4, 1, '2023-01-01', 'Reichlich Schokolade', 'Auf allen drei Stockwerke sollten 4 verschiedene Schokoladenarten angeboten werden.'),

--- a/backend/src/test/java/ch/puzzle/okr/controller/KeyResultControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/KeyResultControllerIT.java
@@ -55,7 +55,7 @@ class KeyResultControllerIT {
     static MeasureDto measureDto2 = new MeasureDto(4L, 5L, 12, "Changeinfo2", "Ininitatives2", 1L, LocalDateTime.MAX,
             LocalDateTime.of(2022, 10, 18, 10, 33));
     static KeyResultDto keyResultDto = new KeyResultDto(5L, 5L, "Keyresult", "", 5L, "", "", ExpectedEvolution.INCREASE,
-            Unit.PERCENT, 0L, 1L);
+            Unit.PERCENT, 0L, 1L, 0L);
     static Objective objective = Objective.Builder.builder().withId(5L).withTitle("Objective 1").build();
     static KeyResult keyResult = KeyResult.Builder.builder().withId(5L).withTitle("test").withObjective(objective)
             .withOwner(user).build();
@@ -136,7 +136,7 @@ class KeyResultControllerIT {
     @Test
     void shouldGetKeyresultWithId() throws Exception {
         KeyResultDto testKeyResult = new KeyResultDto(1L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
         BDDMockito.given(keyResultService.getKeyResultById(1)).willReturn(keyResult1);
         BDDMockito.given(this.keyResultMapper.toDto(any())).willReturn(testKeyResult);
 
@@ -160,7 +160,7 @@ class KeyResultControllerIT {
     void shouldReturnUpdatedKeyResult() throws Exception {
         KeyResult keyResult = KeyResult.Builder.builder().withId(1L).withTitle("Updated Keyresult 1").build();
         KeyResultDto testKeyResult = new KeyResultDto(1L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
 
         BDDMockito.given(keyResultService.updateKeyResult(any())).willReturn(keyResult);
         BDDMockito.given(keyResultMapper.toDto(any())).willReturn(testKeyResult);
@@ -185,7 +185,7 @@ class KeyResultControllerIT {
     @Test
     void createKeyResult() throws Exception {
         KeyResultDto testKeyResult = new KeyResultDto(5L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
 
         BDDMockito.given(this.keyResultService.getOwnerById(5)).willReturn(user);
         BDDMockito.given(this.keyResultService.getObjectivebyId(5)).willReturn(objective);
@@ -202,7 +202,7 @@ class KeyResultControllerIT {
     @Test
     void createKeyResultWithEnumKeys() throws Exception {
         KeyResultDto testKeyResult = new KeyResultDto(5L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
 
         BDDMockito.given(this.keyResultService.getOwnerById(5)).willReturn(user);
         BDDMockito.given(this.keyResultService.getObjectivebyId(5)).willReturn(objective);

--- a/backend/src/test/java/ch/puzzle/okr/controller/MeasureControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/MeasureControllerIT.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -162,13 +163,14 @@ class MeasureControllerIT {
 
     @Test
     void shouldDeleteMeasure() throws Exception {
+        when(measureService.getMeasureById(anyLong())).thenReturn(measure);
         mvc.perform(delete("/api/v1/measures/10")).andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
     void throwExceptionWhenMeasureWithIdCantBeFoundWhileDeleting() throws Exception {
         doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Measure with measureId 100 not found"))
-                .when(measureService).deleteMeasureById(any());
+                .when(measureService).getMeasureById(anyLong());
 
         mvc.perform(delete("/api/v1/measures/1000")).andExpect(MockMvcResultMatchers.status().isNotFound());
     }

--- a/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
@@ -64,13 +64,13 @@ class ObjectiveControllerIT {
             LocalDateTime.of(2022, 8, 12, 1, 1));
     static List<KeyResultMeasureDto> keyResultsMeasureList = List.of(
             new KeyResultMeasureDto(5L, 1L, "Keyresult 1", "Description", 1L, "Paco", "Egiman",
-                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, measure1Dto),
+                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, measure1Dto, 0L),
             new KeyResultMeasureDto(7L, 1L, "Keyresult 2", "Description", 1L, "Robin", "Papier",
-                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, measure2Dto));
+                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, measure2Dto, 0L));
     static KeyResultDto keyresult1Dto = new KeyResultDto(5L, 1L, "Keyresult 1", "Description", 1L, "Alice",
-            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L);
+            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, 0L);
     static KeyResultDto keyresult2Dto = new KeyResultDto(7L, 1L, "Keyresult 2", "Description", 1L, "Alice",
-            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L);
+            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, 0L);
 
     @Autowired
     private MockMvc mvc;

--- a/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
@@ -190,7 +190,7 @@ class ObjectiveControllerIT {
                 .withTitle("Hunting").build();
 
         BDDMockito.given(objectiveMapper.toDto(any())).willReturn(testObjective);
-        BDDMockito.given(objectiveService.updateObjective(anyLong(), any())).willReturn(objective);
+        BDDMockito.given(objectiveService.updateObjective(any())).willReturn(objective);
 
         mvc.perform(put("/api/v1/objectives/10").contentType(MediaType.APPLICATION_JSON)
                 .content("{\"title\": \"FullObjective\", \"ownerId\": 1, \"ownerFirstname\": \"Bob\", "
@@ -204,7 +204,7 @@ class ObjectiveControllerIT {
 
     @Test
     void shouldReturnNotFound() throws Exception {
-        BDDMockito.given(objectiveService.updateObjective(anyLong(), any())).willThrow(
+        BDDMockito.given(objectiveService.updateObjective(any())).willThrow(
                 new ResponseStatusException(HttpStatus.NOT_FOUND, "Failed objective -> Attribut is invalid"));
 
         mvc.perform(put("/api/v1/objectives/10").contentType(MediaType.APPLICATION_JSON)
@@ -217,7 +217,7 @@ class ObjectiveControllerIT {
 
     @Test
     void shouldReturnBadRequest() throws Exception {
-        BDDMockito.given(objectiveService.updateObjective(anyLong(), any())).willThrow(
+        BDDMockito.given(objectiveService.updateObjective(any())).willThrow(
                 new ResponseStatusException(HttpStatus.BAD_REQUEST, "Failed objective -> Attribut is invalid"));
 
         mvc.perform(put("/api/v1/objectives/10")).andExpect(MockMvcResultMatchers.status().isBadRequest());

--- a/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
@@ -170,7 +170,7 @@ class KeyResultServiceTest {
         when(keyResultRepository.findByObjective(any())).thenReturn(keyResults);
         when(keyResultMeasureMapper.toDto(keyResult, measure1)).thenReturn(new KeyResultMeasureDto(5L, 1L,
                 "Keyresult 1", "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L,
-                new MeasureDto(1L, 1L, 10, "", "", 1L, null, null)));
+                new MeasureDto(1L, 1L, 10, "", "", 1L, null, null), 0L));
 
         List<KeyResultMeasureDto> keyResultList = keyResultService.getAllKeyResultsByObjectiveWithMeasure(1L);
 
@@ -186,7 +186,7 @@ class KeyResultServiceTest {
         when(measureRepository.findLastMeasuresOfKeyresults(any())).thenReturn(measures);
         when(keyResultRepository.findByObjective(any())).thenReturn(keyResults);
         when(keyResultMeasureMapper.toDto(any(), any())).thenReturn(new KeyResultMeasureDto(5L, 1L, "Keyresult 1",
-                "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, null));
+                "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, null, 0L));
 
         List<KeyResultMeasureDto> keyResultList = keyResultService.getAllKeyResultsByObjectiveWithMeasure(1L);
 

--- a/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
@@ -183,7 +183,7 @@ class ObjectiveServiceTest {
 
     @Test
     void shouldReturnObjectiveProperly() {
-        Objective newObjective = Objective.Builder.builder().withTitle("Hello World")
+        Objective newObjective = Objective.Builder.builder().withTitle("Hello World").withId(1L)
                 .withDescription("This is a cool objective")
                 .withOwner(User.Builder.builder().withUsername("rudi").build()).withProgress(5L).withQuarter(null)
                 .withCreatedOn(LocalDateTime.now())
@@ -191,31 +191,11 @@ class ObjectiveServiceTest {
         Mockito.when(objectiveRepository.findById(anyLong())).thenReturn(Optional.of(newObjective));
         Mockito.when(objectiveRepository.save(any())).thenReturn(newObjective);
 
-        Objective returnedObjective = objectiveService.updateObjective(1L, newObjective);
+        Objective returnedObjective = objectiveService.updateObjective(newObjective);
         assertEquals("Hello World", returnedObjective.getTitle());
         assertEquals("Best Team", returnedObjective.getTeam().getName());
         assertEquals("rudi", returnedObjective.getOwner().getUsername());
         assertEquals("This is a cool objective", returnedObjective.getDescription());
-    }
-
-    @Test
-    void shouldThrowBadRequestException() {
-        Objective newObjective = Objective.Builder.builder().withId(1L).withTitle("Hello World")
-                .withDescription("This is a cool objective")
-                .withOwner(User.Builder.builder().withUsername("rudi").build()).withProgress(5L)
-                .withQuarter(new Quarter()).withCreatedOn(LocalDateTime.now())
-                .withTeam(Team.Builder.builder().withId(1L).withName("Best Team").build()).build();
-        KeyResult testKeyResult = KeyResult.Builder.builder().withObjective(newObjective).build();
-        List<KeyResult> keyResultList = List.of(testKeyResult);
-
-        Mockito.when(objectiveRepository.findById(anyLong())).thenReturn(Optional.of(newObjective));
-        Mockito.when(objectiveRepository.save(any())).thenReturn(newObjective);
-        Mockito.when(keyResultRepository.findAll()).thenReturn(keyResultList);
-
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
-                () -> this.objectiveService.updateObjective(1L, newObjective));
-        assertEquals("Can't set the progress of an objective if you have already defined keyresults!",
-                exception.getReason());
     }
 
     @Test

--- a/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
@@ -118,7 +118,7 @@ class ObjectiveServiceTest {
         assertNull(savedObjective.getId());
         assertEquals("FullObjective1", savedObjective.getTitle());
         assertEquals("This is our description", savedObjective.getDescription());
-        assertEquals(0, savedObjective.getProgress());
+        assertEquals(null, savedObjective.getProgress());
         assertEquals("Team1", savedObjective.getTeam().getName());
         assertEquals("Bob", savedObjective.getOwner().getFirstname());
         assertEquals("GJ 22/23-Q2", savedObjective.getQuarter().getLabel());

--- a/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
@@ -118,7 +118,7 @@ class ObjectiveServiceTest {
         assertNull(savedObjective.getId());
         assertEquals("FullObjective1", savedObjective.getTitle());
         assertEquals("This is our description", savedObjective.getDescription());
-        assertEquals(null, savedObjective.getProgress());
+        assertNull(savedObjective.getProgress());
         assertEquals("Team1", savedObjective.getTeam().getName());
         assertEquals("Bob", savedObjective.getOwner().getFirstname());
         assertEquals("GJ 22/23-Q2", savedObjective.getQuarter().getLabel());

--- a/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
@@ -63,7 +63,7 @@ class ProgressServiceTestIT {
     }
 
     private static Stream<Arguments> shouldReturnCorrectProgress() {
-        return Stream.of(Arguments.of(120, 100, 120, 100D), Arguments.of(50, 85, 65, 42.857142857142854D),
+        return Stream.of(Arguments.of(120, 100, 120, 100D), Arguments.of(50, 85, 65, 57.142857142857146D),
                 Arguments.of(100, 0, 80, 80D));
     }
 

--- a/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
@@ -1,40 +1,131 @@
 package ch.puzzle.okr.service;
 
 import ch.puzzle.okr.OkrApplication;
+import ch.puzzle.okr.helper.KeyResultMeasureValue;
+import ch.puzzle.okr.models.KeyResult;
 import ch.puzzle.okr.models.Objective;
+import ch.puzzle.okr.repository.KeyResultRepository;
 import ch.puzzle.okr.repository.ObjectiveRepository;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @Transactional
 @SpringBootTest(classes = OkrApplication.class)
 class ProgressServiceTestIT {
+    // Instances to test Methods which require projection
+    private static ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+    private static KeyResultMeasureValue keyResultMeasureValue = factory.createProjection(KeyResultMeasureValue.class);
     @InjectMocks
+    @Spy
     private ProgressService progressService;
     @Mock
     private ObjectiveService objectiveService;
     @Mock
     private ObjectiveRepository objectiveRepository;
+    @Mock
+    private KeyResultRepository keyResultRepository;
+
+    // Data for parameterized test
+    private static Stream<Arguments> shouldReturnCorrectKeyResultProgress() {
+        return Stream.of(Arguments.of(null, 11.5D, null), Arguments.of(keyResultMeasureValue, 50.25D, 50L),
+                Arguments.of(keyResultMeasureValue, 15.789D, 15L), Arguments.of(keyResultMeasureValue, 25D, 25L));
+    }
+
+    private static Stream<Arguments> shouldCalculateObjectiveProgress() {
+        return Stream.of(Arguments.of(List.of(keyResultMeasureValue, keyResultMeasureValue), 11.5D, 11L),
+                Arguments.of(List.of(keyResultMeasureValue, keyResultMeasureValue, keyResultMeasureValue), 56.7D, 56L),
+                Arguments.of(List.of(keyResultMeasureValue), 100D, 100L), Arguments.of(List.of(), 0D, null));
+    }
+
+    private static Stream<Arguments> shouldReturnProgressRestrictedFromOneToHundred() {
+        return Stream.of(Arguments.of(120D, 100D), Arguments.of(50D, 50D), Arguments.of(-50D, 0D),
+                Arguments.of(25D, 25D));
+    }
+
+    private static Stream<Arguments> shouldReturnCorrectProgress() {
+        return Stream.of(Arguments.of(120, 100, 120, 100D), Arguments.of(50, 85, 65, 42.857142857142854D),
+                Arguments.of(100, 0, 80, 80D));
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Reset Values to zero
+        keyResultMeasureValue.setTargetValue(0);
+        keyResultMeasureValue.setBasisValue(0);
+        keyResultMeasureValue.setValue(0);
+    }
 
     @Test
-    @Disabled
-    void checkUpdateProgressMethod() {
-        Objective objective = new Objective.Builder().withId(1L).withProgress(30L).build();
-        when(this.objectiveService.getObjective(1L)).thenReturn(objective);
-        // when(this.objectiveRepository.getProgressOfObjective(1L)).thenReturn(30D);
-        //
-        // this.progressService.updateObjectiveProgress(1L);
-        // verify(this.objectiveRepository, times(1)).getProgressOfObjective(1L);
+    void shouldMakeCallsToUpdateObjectiveProgress() {
+        Objective objective = new Objective();
+        when(this.objectiveService.getObjective(anyLong())).thenReturn(objective);
+        when(this.objectiveRepository.getCalculationValuesForProgress(anyLong()))
+                .thenReturn(List.of(keyResultMeasureValue, keyResultMeasureValue));
+        when(this.progressService.calculateObjectiveProgress(anyList())).thenReturn(null);
+        when(this.keyResultRepository.findByObjective(objective)).thenReturn(List.of(new KeyResult()));
+
+        this.progressService.updateObjectiveProgress(1L);
+
+        verify(this.objectiveService, times(1)).getObjective(anyLong());
         verify(this.objectiveRepository, times(1)).save(objective);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldReturnCorrectKeyResultProgress(KeyResultMeasureValue keyResultMeasureValue, Double checkedProgress,
+            Long expectedProgress) {
+        when(this.keyResultRepository.getProgressValuesKeyResult(1L)).thenReturn(keyResultMeasureValue);
+        if (keyResultMeasureValue != null) {
+            when(this.progressService.returnCheckedProgress(keyResultMeasureValue)).thenReturn(checkedProgress);
+        }
+        Long calculatedProgress = this.progressService.updateKeyResultProgress(1L);
+        assertEquals(expectedProgress, calculatedProgress);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldCalculateObjectiveProgress(List<KeyResultMeasureValue> keyResultMeasureValues, Double checkedProgress,
+            Long expectedProgress) {
+        when(this.progressService.returnCheckedProgress(keyResultMeasureValue)).thenReturn(checkedProgress);
+        Long calculatedProgress = this.progressService.calculateObjectiveProgress(keyResultMeasureValues);
+        assertEquals(expectedProgress, calculatedProgress);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldReturnProgressRestrictedFromOneToHundred(Double progress, Double optimizedProgress) {
+        when(progressService.calculateKeyResultProgress(keyResultMeasureValue)).thenReturn(progress);
+        Double calculatedProgress = this.progressService.returnCheckedProgress(keyResultMeasureValue);
+        assertEquals(optimizedProgress, calculatedProgress);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldReturnCorrectProgress(int targetValue, int basisValue, int value, Double expectedProgress) {
+        keyResultMeasureValue.setTargetValue(targetValue);
+        keyResultMeasureValue.setBasisValue(basisValue);
+        keyResultMeasureValue.setValue(value);
+        Double progress = progressService.calculateKeyResultProgress(keyResultMeasureValue);
+        assertEquals(expectedProgress, progress);
     }
 }

--- a/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
@@ -3,6 +3,7 @@ package ch.puzzle.okr.service;
 import ch.puzzle.okr.OkrApplication;
 import ch.puzzle.okr.models.Objective;
 import ch.puzzle.okr.repository.ObjectiveRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,13 +27,14 @@ class ProgressServiceTestIT {
     private ObjectiveRepository objectiveRepository;
 
     @Test
+    @Disabled
     void checkUpdateProgressMethod() {
         Objective objective = new Objective.Builder().withId(1L).withProgress(30L).build();
         when(this.objectiveService.getObjective(1L)).thenReturn(objective);
-        when(this.objectiveRepository.getProgressOfObjective(1L)).thenReturn(30D);
-
-        this.progressService.updateObjectiveProgress(1L);
-        verify(this.objectiveRepository, times(1)).getProgressOfObjective(1L);
+//        when(this.objectiveRepository.getProgressOfObjective(1L)).thenReturn(30D);
+//
+//        this.progressService.updateObjectiveProgress(1L);
+//        verify(this.objectiveRepository, times(1)).getProgressOfObjective(1L);
         verify(this.objectiveRepository, times(1)).save(objective);
     }
 }

--- a/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ProgressServiceTestIT.java
@@ -31,10 +31,10 @@ class ProgressServiceTestIT {
     void checkUpdateProgressMethod() {
         Objective objective = new Objective.Builder().withId(1L).withProgress(30L).build();
         when(this.objectiveService.getObjective(1L)).thenReturn(objective);
-//        when(this.objectiveRepository.getProgressOfObjective(1L)).thenReturn(30D);
-//
-//        this.progressService.updateObjectiveProgress(1L);
-//        verify(this.objectiveRepository, times(1)).getProgressOfObjective(1L);
+        // when(this.objectiveRepository.getProgressOfObjective(1L)).thenReturn(30D);
+        //
+        // this.progressService.updateObjectiveProgress(1L);
+        // verify(this.objectiveRepository, times(1)).getProgressOfObjective(1L);
         verify(this.objectiveRepository, times(1)).save(objective);
     }
 }

--- a/frontend/src/app/keyresult/key-result-row/key-result-row.component.html
+++ b/frontend/src/app/keyresult/key-result-row/key-result-row.component.html
@@ -24,7 +24,7 @@
             <span class="h6">-</span>
           </ng-template>
           <app-progress-bar
-            [value]="progressPercentage"
+            [value]="keyResult.progress"
             [colorLow]="'#FF1A0C'"
             [colorMiddle]="'#FFA012'"
             [colorHigh]="'#29DF0B'"

--- a/frontend/src/app/keyresult/key-result-row/key-result-row.component.html
+++ b/frontend/src/app/keyresult/key-result-row/key-result-row.component.html
@@ -18,7 +18,7 @@
       <div class="d-flex w-50">
         <div class="w-100" id="progressContainer">
           <span class="h6" *ngIf="keyResult.measure; else noMeasure"
-            >{{ progressPercentage }}%</span
+            >{{ keyResult.progress }}%</span
           >
           <ng-template #noMeasure>
             <span class="h6">-</span>

--- a/frontend/src/app/keyresult/key-result-row/key-result-row.component.ts
+++ b/frontend/src/app/keyresult/key-result-row/key-result-row.component.ts
@@ -29,7 +29,6 @@ export class KeyResultRowComponent implements OnInit {
   @Input() objectiveId!: number;
   @Output() onKeyresultListUpdate: EventEmitter<any> = new EventEmitter();
   menuEntries!: MenuEntry[];
-  progressPercentage!: number;
 
   constructor(
     private datePipe: DatePipe,
@@ -40,15 +39,6 @@ export class KeyResultRowComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const elementMeasureValue =
-      this.keyResult.measure != null ? this.keyResult.measure?.value : 0;
-    const elementMeasureTargetValue = this.keyResult.targetValue;
-    const elementMeasureBasicValue = this.keyResult.basicValue;
-    this.calculateProgress(
-      elementMeasureValue,
-      elementMeasureTargetValue,
-      elementMeasureBasicValue
-    );
     this.menuEntries = [
       {
         displayName: 'KeyResult bearbeiten',
@@ -141,23 +131,5 @@ export class KeyResultRowComponent implements OnInit {
         dialogRef.close();
       }
     });
-  }
-
-  private calculateProgress(
-    elementMeasureValue: number,
-    elementMeasureTargetValue: number,
-    elementMeasureBasicValue: number
-  ) {
-    if (elementMeasureValue === 0) {
-      this.progressPercentage = 0;
-    } else {
-      this.progressPercentage = Math.abs(
-        Math.round(
-          (elementMeasureValue /
-            (elementMeasureTargetValue - elementMeasureBasicValue)) *
-            100
-        )
-      );
-    }
   }
 }

--- a/frontend/src/app/keyresult/keyresult-form/keyresult-form.component.ts
+++ b/frontend/src/app/keyresult/keyresult-form/keyresult-form.component.ts
@@ -96,6 +96,7 @@ export class KeyresultFormComponent implements OnInit {
         ownerFirstname,
         ownerLastname,
         measure,
+        progress,
         ...restKeyresult
       } = keyresult;
       this.keyResultForm.setValue(restKeyresult);

--- a/frontend/src/app/objective/objective-row/objective-row.component.html
+++ b/frontend/src/app/objective/objective-row/objective-row.component.html
@@ -6,9 +6,11 @@
     <mat-panel-description class="d-flex space-between">
       <div class="d-flex w-50 margin-left">
         <div class="w-100" id="progressContainer">
-          <span class="h6" id="progressSpan">{{ objective!.progress }}%</span>
+          <span class="h6" id="progressSpan">{{
+            objective!.progress != null ? objective!.progress + "%" : "-"
+          }}</span>
           <app-progress-bar
-            [value]="objective!.progress!"
+            [value]="objective!.progress! != null ? objective!.progress! : 0"
             [colorLow]="'#FF1A0C'"
             [colorMiddle]="'#FFA012'"
             [colorHigh]="'#29DF0B'"

--- a/frontend/src/app/shared/services/key-result.service.ts
+++ b/frontend/src/app/shared/services/key-result.service.ts
@@ -27,6 +27,7 @@ export interface KeyResultMeasure {
   basicValue: number;
   targetValue: number;
   measure?: Measure;
+  progress: number;
 }
 
 @Injectable({
@@ -68,6 +69,7 @@ export class KeyResultService {
       targetValue: 1,
       basicValue: 1,
       objectiveId: 1,
+      progress: 0,
     };
   }
 

--- a/frontend/src/app/shared/testing/mock-data/keyresults.json
+++ b/frontend/src/app/shared/testing/mock-data/keyresults.json
@@ -21,7 +21,8 @@
         "createdById": 1,
         "createdOn": "2023-01-18",
         "measureDate": "2022-12-23"
-      }
+      },
+      "progress": 60
     },
     {
       "id": 2,
@@ -44,7 +45,8 @@
         "createdById": 1,
         "createdOn": "2019-08-22",
         "measureDate": "2020-11-03"
-      }
+      },
+      "progress": 0
     },
     {
       "id": 3,
@@ -67,7 +69,8 @@
         "createdById": 1,
         "createdOn": "2023-02-14",
         "measureDate": "2023-03-06"
-      }
+      },
+      "progress": 0
     }
   ],
   "createKeyResultObject": {
@@ -81,7 +84,8 @@
     "ownerFirstname": "",
     "targetValue": 100,
     "basicValue": 0,
-    "objectiveId": 1
+    "objectiveId": 1,
+    "progress": 0
   },
   "initKeyResult": {
     "id": null,
@@ -94,7 +98,8 @@
     "ownerFirstname": "",
     "targetValue": 1,
     "basicValue": 1,
-    "objectiveId": 3000
+    "objectiveId": 3000,
+    "progress": 0
   },
   "binaryKeyresult": {
     "id": 5,
@@ -117,6 +122,7 @@
       "createdById": 1,
       "createdOn": "2023-02-14",
       "measureDate": "2023-03-06"
-    }
+    },
+    "progress": 0
   }
 }


### PR DESCRIPTION
Was gemacht wurde: 
- Progressberechnung wurde komplett in den ProgressService verlagert
- Objectives zeigen ein "-" an, anstatt 0% wenn keine Keyresults darunter sind
- Progressberechnung der Keyresults wurde in das Backend verlagert, der Progress der Keyresults wird nun per DTO übertragen
- Progressberechnung im Frontend wurde entfernt
- Update des Progress von Objective wurde für das Löschen eines Measures hinzugefügt
- Tests für den  Measure Controller dementsprechend angepasst.