### PR TITLE
Feature/12 objectives löschen

### DIFF
--- a/backend/src/main/java/ch/puzzle/okr/controller/KeyResultController.java
+++ b/backend/src/main/java/ch/puzzle/okr/controller/KeyResultController.java
@@ -91,6 +91,6 @@ public class KeyResultController {
             @ApiResponse(responseCode = "404", description = "Did not find the keyresult with requested id") })
     @DeleteMapping("/{id}")
     public void deleteKeyResultById(@PathVariable long id) {
-        keyResultService.deleteKeyResultById(id);
+        keyResultService.deleteKeyResultAndUpdateProgress(id);
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/controller/ObjectiveController.java
+++ b/backend/src/main/java/ch/puzzle/okr/controller/ObjectiveController.java
@@ -90,4 +90,12 @@ public class ObjectiveController {
             @Parameter(description = "The ID for getting all KeyResults from an Objective.", required = true) @PathVariable Long id) {
         return keyResultService.getAllKeyResultsByObjectiveWithMeasure(id);
     }
+
+    @Operation(summary = "Delete Objective by Id", description = "Delete Objective by Id")
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Deleted objective by Id"),
+            @ApiResponse(responseCode = "404", description = "Did not find the objective with requested id") })
+    @DeleteMapping("/{id}")
+    public void deleteObjectiveById(@PathVariable long id) {
+        this.objectiveService.deleteObjectiveById(id);
+    }
 }

--- a/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
@@ -16,18 +16,16 @@ import java.util.Objects;
 public class KeyResultService {
 
     private final KeyResultRepository keyResultRepository;
-    private final QuarterRepository quarterRepository;
     private final UserRepository userRepository;
     private final ObjectiveRepository objectiveRepository;
     private final MeasureRepository measureRepository;
     private final KeyResultMeasureMapper keyResultMeasureMapper;
     private final ProgressService progressService;
 
-    public KeyResultService(KeyResultRepository keyResultRepository, QuarterRepository quarterRepository,
-            UserRepository userRepository, ObjectiveRepository objectiveRepository, MeasureRepository measureRepository,
+    public KeyResultService(KeyResultRepository keyResultRepository, UserRepository userRepository,
+            ObjectiveRepository objectiveRepository, MeasureRepository measureRepository,
             KeyResultMeasureMapper keyResultMeasureMapper, ProgressService progressService) {
         this.keyResultRepository = keyResultRepository;
-        this.quarterRepository = quarterRepository;
         this.userRepository = userRepository;
         this.objectiveRepository = objectiveRepository;
         this.measureRepository = measureRepository;
@@ -104,8 +102,8 @@ public class KeyResultService {
 
     @Transactional
     public void deleteKeyResultAndUpdateProgress(Long id) {
-        deleteKeyResultById(id);
         Long objectiveId = getKeyResultById(id).getObjective().getId();
+        deleteKeyResultById(id);
         this.progressService.updateObjectiveProgress(objectiveId);
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
@@ -96,11 +96,16 @@ public class KeyResultService {
     @Transactional
     public void deleteKeyResultById(Long id) {
         List<Measure> measures = getAllMeasuresByKeyResult(id);
-        Long objectiveId = getKeyResultById(id).getObjective().getId();
         for (Measure measure : measures) {
             measureRepository.deleteById(measure.getId());
         }
         keyResultRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void deleteKeyResultAndUpdateProgress(Long id) {
+        deleteKeyResultById(id);
+        Long objectiveId = getKeyResultById(id).getObjective().getId();
         this.progressService.updateObjectiveProgress(objectiveId);
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
@@ -85,7 +85,7 @@ public class ObjectiveService {
     }
 
     @Transactional
-    public void deleteKeyObjectiveById(Long id) {
+    public void deleteObjectiveById(Long id) {
         List<KeyResult> keyResults = this.keyResultRepository.findByObjective(this.getObjective(id));
         for (KeyResult keyResult : keyResults) {
             this.keyResultService.deleteKeyResultById(keyResult.getId());

--- a/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
@@ -16,12 +17,14 @@ public class ObjectiveService {
     private final ObjectiveRepository objectiveRepository;
     private final KeyResultRepository keyResultRepository;
     private final TeamRepository teamRepository;
+    private final KeyResultService keyResultService;
 
     public ObjectiveService(ObjectiveRepository objectiveRepository, KeyResultRepository keyResultRepository,
-            TeamRepository teamRepository) {
+            TeamRepository teamRepository, KeyResultService keyResultService) {
         this.objectiveRepository = objectiveRepository;
         this.keyResultRepository = keyResultRepository;
         this.teamRepository = teamRepository;
+        this.keyResultService = keyResultService;
     }
 
     public List<Objective> getAllObjectives() {
@@ -78,5 +81,14 @@ public class ObjectiveService {
     public List<Objective> getObjectiveByTeamIdAndQuarterId(Long teamId, Long quarterId) {
         return quarterId == null ? objectiveRepository.findByTeamId(teamId)
                 : objectiveRepository.findByQuarterIdAndTeamId(quarterId, teamId);
+    }
+
+    @Transactional
+    public void deleteKeyObjectiveById(Long id) {
+        List<KeyResult> keyResults = this.keyResultRepository.findByObjective(this.getObjective(id));
+        for (KeyResult keyResult : keyResults) {
+            // TODO: Call KeyResultService to delete every Measure on the keyresult
+        }
+        this.objectiveRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ObjectiveService.java
@@ -5,6 +5,7 @@ import ch.puzzle.okr.models.Objective;
 import ch.puzzle.okr.repository.KeyResultRepository;
 import ch.puzzle.okr.repository.ObjectiveRepository;
 import ch.puzzle.okr.repository.TeamRepository;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -20,7 +21,7 @@ public class ObjectiveService {
     private final KeyResultService keyResultService;
 
     public ObjectiveService(ObjectiveRepository objectiveRepository, KeyResultRepository keyResultRepository,
-            TeamRepository teamRepository, KeyResultService keyResultService) {
+            TeamRepository teamRepository, @Lazy KeyResultService keyResultService) {
         this.objectiveRepository = objectiveRepository;
         this.keyResultRepository = keyResultRepository;
         this.teamRepository = teamRepository;
@@ -87,7 +88,7 @@ public class ObjectiveService {
     public void deleteKeyObjectiveById(Long id) {
         List<KeyResult> keyResults = this.keyResultRepository.findByObjective(this.getObjective(id));
         for (KeyResult keyResult : keyResults) {
-            // TODO: Call KeyResultService to delete every Measure on the keyresult
+            this.keyResultService.deleteKeyResultById(keyResult.getId());
         }
         this.objectiveRepository.deleteById(id);
     }

--- a/backend/src/test/java/ch/puzzle/okr/controller/KeyResultControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/KeyResultControllerIT.java
@@ -296,7 +296,7 @@ class KeyResultControllerIT {
     @Test
     void throwExceptionWhenKeyresultWithIdCantBeFoundWhileDeleting() throws Exception {
         doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Keyresult not found")).when(keyResultService)
-                .deleteKeyResultById(any());
+                .deleteKeyResultAndUpdateProgress(any());
 
         mvc.perform(delete("/api/v1/keyresults/1000")).andExpect(MockMvcResultMatchers.status().isNotFound());
     }

--- a/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
@@ -32,8 +32,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -221,5 +220,18 @@ class ObjectiveControllerIT {
                 new ResponseStatusException(HttpStatus.BAD_REQUEST, "Failed objective -> Attribut is invalid"));
 
         mvc.perform(put("/api/v1/objectives/10")).andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    void shouldDeleteObjective() throws Exception {
+        mvc.perform(delete("/api/v1/objectives/10")).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void throwExceptionWhenObjectiveWithIdCantBeFoundWhileDeleting() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Objective not found")).when(objectiveService)
+                .deleteObjectiveById(anyLong());
+
+        mvc.perform(delete("/api/v1/objectives/1000")).andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 }

--- a/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
@@ -199,7 +199,7 @@ class KeyResultServiceTest {
         when(measureRepository.findByKeyResult(any())).thenReturn(measures);
         when(keyResultRepository.findById(1L)).thenReturn(Optional.of(keyResult));
 
-        keyResultService.deleteKeyResultById(1L);
+        keyResultService.deleteKeyResultAndUpdateProgress(1L);
 
         verify(keyResultRepository, times(1)).deleteById(1L);
         verify(measureRepository, times(1)).findByKeyResult(keyResult);

--- a/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
@@ -195,6 +195,21 @@ class KeyResultServiceTest {
     }
 
     @Test
+    void shouldDeleteKeyResultWithoutUpdateProgress() {
+        when(measureRepository.findByKeyResult(any())).thenReturn(measures);
+        when(keyResultRepository.findById(1L)).thenReturn(Optional.of(keyResult));
+
+        keyResultService.deleteKeyResultById(1L);
+
+        verify(measureRepository, times(1)).findByKeyResult(keyResult);
+        verify(measureRepository, times(1)).deleteById(1L);
+        verify(measureRepository, times(1)).deleteById(2L);
+        verify(measureRepository, times(1)).deleteById(3L);
+        verify(keyResultRepository, times(1)).deleteById(1L);
+        verify(progressService, never()).updateObjectiveProgress(any());
+    }
+
+    @Test
     void shouldDeleteKeyResultAndAssociatedMeasures() {
         when(measureRepository.findByKeyResult(any())).thenReturn(measures);
         when(keyResultRepository.findById(1L)).thenReturn(Optional.of(keyResult));

--- a/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/ObjectiveServiceTest.java
@@ -33,7 +33,8 @@ class ObjectiveServiceTest {
     ObjectiveRepository objectiveRepository = Mockito.mock(ObjectiveRepository.class);
     @MockBean
     KeyResultRepository keyResultRepository = Mockito.mock(KeyResultRepository.class);
-
+    @MockBean
+    KeyResultService keyResultService = Mockito.mock(KeyResultService.class);
     @MockBean
     TeamRepository teamRepository = Mockito.mock(TeamRepository.class);
 
@@ -228,5 +229,16 @@ class ObjectiveServiceTest {
         objectiveService.getObjectiveByTeamIdAndQuarterId(teamId, quarterId);
         verify(objectiveRepository, times(invocationsByTeam)).findByTeamId(teamId);
         verify(objectiveRepository, times(invocationsByTeamAndQuarter)).findByQuarterIdAndTeamId(teamId, quarterId);
+    }
+
+    @Test
+    void shouldDeleteObjectiveAndAssociatedKeyResults() {
+        when(this.objectiveRepository.findById(anyLong())).thenReturn(Optional.of(objective));
+        when(this.keyResultRepository.findByObjective(objective)).thenReturn(keyResults);
+
+        this.objectiveService.deleteObjectiveById(1L);
+
+        verify(this.keyResultService, times(3)).deleteKeyResultById(5L);
+        verify(this.objectiveRepository, times(1)).deleteById(anyLong());
     }
 }


### PR DESCRIPTION
Was gemacht wurde:
- Im ObjectiveService wurde eine Methode annotiert mit @Transactional erstellt, welche alle Keyresults eines Objectives holt diese per KeyResultService löscht und nach allem Löschen das Objective löscht.

- Die Methode welche alle Keyresults löscht wurde in zwei Teile gesägt: deleteKeyResultsbyId() und deleteKeyResultsAndUpdateProgress(). Falls wir das Objective löschen, müssen wir den Progress nicht immer updaten, falls wir das KeyResult löschen, ist das Update des Progresses notwendig

- Die Schnittstelle für das Löschen der Objectives wurde ebenfalls implementiert.

-  Schnittstelle sowie Methode im Service wurden getestet