### PR TITLE
Feature/138 nachkommastelle keyresult

### DIFF
--- a/backend/src/main/java/ch/puzzle/okr/dto/KeyResultDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/KeyResultDto.java
@@ -13,13 +13,13 @@ public class KeyResultDto {
     private String ownerLastname;
     private ExpectedEvolution expectedEvolution;
     private Unit unit;
-    private Long basicValue;
-    private Long targetValue;
+    private Double basicValue;
+    private Double targetValue;
     private Long progress;
 
     public KeyResultDto(Long id, Long objectiveId, String title, String description, Long ownerId,
             String ownerFirstname, String ownerLastname, ExpectedEvolution expectedEvolution, Unit unit,
-            Long basicValue, Long targetValue, Long progress) {
+            Double basicValue, Double targetValue, Long progress) {
         this.id = id;
         this.objectiveId = objectiveId;
         this.title = title;
@@ -106,19 +106,19 @@ public class KeyResultDto {
         this.unit = unit;
     }
 
-    public Long getBasicValue() {
+    public Double getBasicValue() {
         return basicValue;
     }
 
-    public void setBasicValue(Long basicValue) {
+    public void setBasicValue(Double basicValue) {
         this.basicValue = basicValue;
     }
 
-    public Long getTargetValue() {
+    public Double getTargetValue() {
         return targetValue;
     }
 
-    public void setTargetValue(Long targetValue) {
+    public void setTargetValue(Double targetValue) {
         this.targetValue = targetValue;
     }
 

--- a/backend/src/main/java/ch/puzzle/okr/dto/KeyResultMeasureDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/KeyResultMeasureDto.java
@@ -13,14 +13,14 @@ public class KeyResultMeasureDto {
     private String ownerLastname;
     private ExpectedEvolution expectedEvolution;
     private Unit unit;
-    private Long basicValue;
-    private Long targetValue;
+    private Double basicValue;
+    private Double targetValue;
     private MeasureDto measure;
     private Long progress;
 
     public KeyResultMeasureDto(Long id, Long objectiveId, String title, String description, Long ownerId,
             String ownerFirstname, String ownerLastname, ExpectedEvolution expectedEvolution, Unit unit,
-            Long basicValue, Long targetValue, MeasureDto measureDto, Long progress) {
+            Double basicValue, Double targetValue, MeasureDto measureDto, Long progress) {
         this.id = id;
         this.objectiveId = objectiveId;
         this.title = title;
@@ -108,19 +108,19 @@ public class KeyResultMeasureDto {
         this.unit = unit;
     }
 
-    public Long getBasicValue() {
+    public Double getBasicValue() {
         return basicValue;
     }
 
-    public void setBasicValue(Long basicValue) {
+    public void setBasicValue(Double basicValue) {
         this.basicValue = basicValue;
     }
 
-    public Long getTargetValue() {
+    public Double getTargetValue() {
         return targetValue;
     }
 
-    public void setTargetValue(Long targetValue) {
+    public void setTargetValue(Double targetValue) {
         this.targetValue = targetValue;
     }
 

--- a/backend/src/main/java/ch/puzzle/okr/dto/MeasureDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/MeasureDto.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 public class MeasureDto {
     private java.lang.Long id;
     private Long keyResultId;
-    private Integer value;
+    private Double value;
     private String changeInfo;
     private String initiatives;
     private Instant measureDate;
     private Long createdById;
     private LocalDateTime createdOn;
 
-    public MeasureDto(Long id, Long keyResultId, Integer value, String changeInfo, String initiatives, Long createdById,
+    public MeasureDto(Long id, Long keyResultId, Double value, String changeInfo, String initiatives, Long createdById,
             LocalDateTime createdOn, Instant measureDate) {
         this.id = id;
         this.keyResultId = keyResultId;
@@ -41,11 +41,11 @@ public class MeasureDto {
         this.keyResultId = keyResultId;
     }
 
-    public Integer getValue() {
+    public Double getValue() {
         return value;
     }
 
-    public void setValue(Integer value) {
+    public void setValue(Double value) {
         this.value = value;
     }
 

--- a/backend/src/main/java/ch/puzzle/okr/dto/goal/GoalDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/goal/GoalDto.java
@@ -13,11 +13,12 @@ public class GoalDto {
     private String quarterLabel;
     private ExpectedEvolution expectedEvolution;
     private Unit unit;
-    private Long basicValue;
-    private Long targetValue;
+    private Double basicValue;
+    private Double targetValue;
 
     public GoalDto(GoalObjectiveDto objective, GoalKeyResultDto keyresult, Team team, Long progress,
-            String quarterLabel, ExpectedEvolution expectedEvolution, Unit unit, Long basicValue, Long targetValue) {
+            String quarterLabel, ExpectedEvolution expectedEvolution, Unit unit, Double basicValue,
+            Double targetValue) {
         this.objective = objective;
         this.keyresult = keyresult;
         this.teamId = team.getId();
@@ -94,19 +95,19 @@ public class GoalDto {
         this.unit = unit;
     }
 
-    public Long getBasicValue() {
+    public Double getBasicValue() {
         return basicValue;
     }
 
-    public void setBasicValue(Long basicValue) {
+    public void setBasicValue(Double basicValue) {
         this.basicValue = basicValue;
     }
 
-    public Long getTargetValue() {
+    public Double getTargetValue() {
         return targetValue;
     }
 
-    public void setTargetValue(Long targetValue) {
+    public void setTargetValue(Double targetValue) {
         this.targetValue = targetValue;
     }
 }

--- a/backend/src/main/java/ch/puzzle/okr/models/KeyResult.java
+++ b/backend/src/main/java/ch/puzzle/okr/models/KeyResult.java
@@ -33,10 +33,10 @@ public class KeyResult {
     private Unit unit;
 
     @NotNull
-    private Long basisValue;
+    private Double basisValue;
 
     @NotNull
-    private Long targetValue;
+    private Double targetValue;
 
     @NotNull
     @ManyToOne
@@ -114,19 +114,19 @@ public class KeyResult {
         this.unit = unit;
     }
 
-    public Long getBasisValue() {
+    public Double getBasisValue() {
         return basisValue;
     }
 
-    public void setBasisValue(Long basisValue) {
+    public void setBasisValue(Double basisValue) {
         this.basisValue = basisValue;
     }
 
-    public Long getTargetValue() {
+    public Double getTargetValue() {
         return targetValue;
     }
 
-    public void setTargetValue(Long targetValue) {
+    public void setTargetValue(Double targetValue) {
         this.targetValue = targetValue;
     }
 
@@ -183,8 +183,8 @@ public class KeyResult {
         private @NotNull User owner;
         private @Size(min = 2, max = 250) ExpectedEvolution expectedEvolution;
         private @NotNull @NotBlank Unit unit;
-        private @NotNull Long basisValue;
-        private @NotNull Long targetValue;
+        private @NotNull Double basisValue;
+        private @NotNull Double targetValue;
         private @NotNull User createdBy;
         private @NotNull LocalDateTime createdOn;
 
@@ -230,12 +230,12 @@ public class KeyResult {
             return this;
         }
 
-        public Builder withBasisValue(@NotNull Long basisValue) {
+        public Builder withBasisValue(@NotNull Double basisValue) {
             this.basisValue = basisValue;
             return this;
         }
 
-        public Builder withTargetValue(@NotNull Long targetValue) {
+        public Builder withTargetValue(@NotNull Double targetValue) {
             this.targetValue = targetValue;
             return this;
         }

--- a/backend/src/main/java/ch/puzzle/okr/models/Measure.java
+++ b/backend/src/main/java/ch/puzzle/okr/models/Measure.java
@@ -18,7 +18,7 @@ public class Measure {
     private KeyResult keyResult;
 
     @NotNull
-    private Integer value;
+    private Double value;
 
     @NotNull
     @NotBlank
@@ -63,11 +63,11 @@ public class Measure {
         this.keyResult = keyResult;
     }
 
-    public Integer getValue() {
+    public Double getValue() {
         return value;
     }
 
-    public void setValue(Integer value) {
+    public void setValue(Double value) {
         this.value = value;
     }
 
@@ -139,7 +139,7 @@ public class Measure {
     public static final class Builder {
         private @NotNull Long id;
         private @NotNull KeyResult keyResult;
-        private @NotNull Integer value;
+        private @NotNull Double value;
         private @NotNull @NotBlank String changeInfo;
         private @Size(max = 4096) String initiatives;
         private @NotNull User createdBy;
@@ -163,7 +163,7 @@ public class Measure {
             return this;
         }
 
-        public Builder withValue(@NotNull Integer value) {
+        public Builder withValue(@NotNull Double value) {
             this.value = value;
             return this;
         }

--- a/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/KeyResultService.java
@@ -39,8 +39,8 @@ public class KeyResultService {
 
     public KeyResult createKeyResult(KeyResult keyResult) {
         if (keyResult.getUnit().equals(Unit.BINARY)) {
-            keyResult.setTargetValue(1L);
-            keyResult.setBasisValue(0L);
+            keyResult.setTargetValue(1D);
+            keyResult.setBasisValue(0D);
         }
         return this.keyResultRepository.save(keyResult);
     }

--- a/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
+++ b/backend/src/main/java/ch/puzzle/okr/service/ProgressService.java
@@ -63,12 +63,11 @@ public class ProgressService {
 
     protected double calculateKeyResultProgress(KeyResultMeasureValue keyResultMeasureValue) {
         if (keyResultMeasureValue.getBasisValue() > keyResultMeasureValue.getTargetValue()) {
-            return turnedCalculation(keyResultMeasureValue.getTargetValue().doubleValue(),
-                    keyResultMeasureValue.getBasisValue().doubleValue(),
-                    keyResultMeasureValue.getValue().doubleValue());
+            return turnedCalculation(keyResultMeasureValue.getTargetValue(), keyResultMeasureValue.getBasisValue(),
+                    keyResultMeasureValue.getValue());
         }
-        return calculate(keyResultMeasureValue.getTargetValue().doubleValue(),
-                keyResultMeasureValue.getBasisValue().doubleValue(), keyResultMeasureValue.getValue().doubleValue());
+        return calculate(keyResultMeasureValue.getTargetValue(), keyResultMeasureValue.getBasisValue(),
+                keyResultMeasureValue.getValue());
     }
 
     public double turnedCalculation(double targetValue, double basisValue, double value) {

--- a/backend/src/test/java/ch/puzzle/okr/controller/GoalControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/GoalControllerIT.java
@@ -48,7 +48,7 @@ class GoalControllerIT {
     static GoalDto goalDto1 = new GoalDto(new GoalObjectiveDto(1L, "Objective 1", "This is Objective description"),
             new GoalKeyResultDto(1L, "Keyresult 1", "This is Keyresult description"),
             Team.Builder.builder().withId(1L).withName("Puzzle").build(), 20L, "GJ 22/23-Q2",
-            ExpectedEvolution.CONSTANT, Unit.PERCENT, 0L, 100L);
+            ExpectedEvolution.CONSTANT, Unit.PERCENT, 0D, 100D);
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/ch/puzzle/okr/controller/KeyResultControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/KeyResultControllerIT.java
@@ -46,17 +46,17 @@ class KeyResultControllerIT {
     static KeyResult keyResult1 = KeyResult.Builder.builder().withId(5L).withTitle("Keyresult 1").build();
     static Measure measure1 = Measure.Builder.builder().withId(1L).withKeyResult(keyResult1).withCreatedBy(user)
             .withCreatedOn(LocalDateTime.MAX).withChangeInfo("Changeinfo1").withInitiatives("Initiatives1")
-            .withValue(23).withMeasureDate(Instant.parse("2021-11-03T05:55:00.00Z")).build();
+            .withValue(23D).withMeasureDate(Instant.parse("2021-11-03T05:55:00.00Z")).build();
     static Measure measure2 = Measure.Builder.builder().withId(4L).withKeyResult(keyResult1).withCreatedBy(user)
             .withCreatedOn(LocalDateTime.MAX).withChangeInfo("Changeinfo2").withInitiatives("Initiatives2")
-            .withValue(12).withMeasureDate(Instant.parse("2022-08-29T22:44:00.00Z")).build();
+            .withValue(12D).withMeasureDate(Instant.parse("2022-08-29T22:44:00.00Z")).build();
     static List<Measure> measureList = Arrays.asList(measure1, measure2);
-    static MeasureDto measureDto1 = new MeasureDto(1L, 5L, 34, "Changeinfo1", "Ininitatives1", 1L, LocalDateTime.MAX,
+    static MeasureDto measureDto1 = new MeasureDto(1L, 5L, 34D, "Changeinfo1", "Ininitatives1", 1L, LocalDateTime.MAX,
             Instant.parse("2022-03-24T18:45:00.00Z"));
-    static MeasureDto measureDto2 = new MeasureDto(4L, 5L, 12, "Changeinfo2", "Ininitatives2", 1L, LocalDateTime.MAX,
+    static MeasureDto measureDto2 = new MeasureDto(4L, 5L, 12D, "Changeinfo2", "Ininitatives2", 1L, LocalDateTime.MAX,
             Instant.parse("2022-10-18T10:33:00.00Z"));
     static KeyResultDto keyResultDto = new KeyResultDto(5L, 5L, "Keyresult", "", 5L, "", "", ExpectedEvolution.INCREASE,
-            Unit.PERCENT, 0L, 1L, 0L);
+            Unit.PERCENT, 0D, 1D, 0L);
     static Objective objective = Objective.Builder.builder().withId(5L).withTitle("Objective 1").build();
     static KeyResult keyResult = KeyResult.Builder.builder().withId(5L).withTitle("test").withObjective(objective)
             .withOwner(user).build();
@@ -137,7 +137,7 @@ class KeyResultControllerIT {
     @Test
     void shouldGetKeyresultWithId() throws Exception {
         KeyResultDto testKeyResult = new KeyResultDto(1L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4D, 12D, 0L);
         BDDMockito.given(keyResultService.getKeyResultById(1)).willReturn(keyResult1);
         BDDMockito.given(this.keyResultMapper.toDto(any())).willReturn(testKeyResult);
 
@@ -161,7 +161,7 @@ class KeyResultControllerIT {
     void shouldReturnUpdatedKeyResult() throws Exception {
         KeyResult keyResult = KeyResult.Builder.builder().withId(1L).withTitle("Updated Keyresult 1").build();
         KeyResultDto testKeyResult = new KeyResultDto(1L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4D, 12D, 0L);
 
         BDDMockito.given(keyResultService.updateKeyResult(any())).willReturn(keyResult);
         BDDMockito.given(keyResultMapper.toDto(any())).willReturn(testKeyResult);
@@ -186,7 +186,7 @@ class KeyResultControllerIT {
     @Test
     void createKeyResult() throws Exception {
         KeyResultDto testKeyResult = new KeyResultDto(5L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4D, 12D, 0L);
 
         BDDMockito.given(this.keyResultService.getOwnerById(5)).willReturn(user);
         BDDMockito.given(this.keyResultService.getObjectivebyId(5)).willReturn(objective);
@@ -203,7 +203,7 @@ class KeyResultControllerIT {
     @Test
     void createKeyResultWithEnumKeys() throws Exception {
         KeyResultDto testKeyResult = new KeyResultDto(5L, 1L, "Program Faster", "Just be faster", 1L, "Rudi", "Grochde",
-                ExpectedEvolution.INCREASE, Unit.PERCENT, 4L, 12L, 0L);
+                ExpectedEvolution.INCREASE, Unit.PERCENT, 4D, 12D, 0L);
 
         BDDMockito.given(this.keyResultService.getOwnerById(5)).willReturn(user);
         BDDMockito.given(this.keyResultService.getObjectivebyId(5)).willReturn(objective);
@@ -232,11 +232,11 @@ class KeyResultControllerIT {
 
         mvc.perform(get("/api/v1/keyresults/5/measures").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andExpect(jsonPath("$", Matchers.hasSize(2)))
-                .andExpect(jsonPath("$[0].id", Is.is(1))).andExpect(jsonPath("$[0].value", Is.is(34)))
+                .andExpect(jsonPath("$[0].id", Is.is(1))).andExpect(jsonPath("$[0].value", Is.is(34D)))
                 .andExpect(jsonPath("$[0].keyResultId", Is.is(5))).andExpect(jsonPath("$[0].createdById", Is.is(1)))
                 .andExpect(jsonPath("$[0].changeInfo", Is.is("Changeinfo1")))
                 .andExpect(jsonPath("$[0].initiatives", Is.is("Ininitatives1")))
-                .andExpect(jsonPath("$[1].id", Is.is(4))).andExpect(jsonPath("$[1].value", Is.is(12)))
+                .andExpect(jsonPath("$[1].id", Is.is(4))).andExpect(jsonPath("$[1].value", Is.is(12D)))
                 .andExpect(jsonPath("$[1].createdById", Is.is(1)))
                 .andExpect(jsonPath("$[1].changeInfo", Is.is("Changeinfo2")))
                 .andExpect(jsonPath("$[1].initiatives", Is.is("Ininitatives2")))

--- a/backend/src/test/java/ch/puzzle/okr/controller/MeasureControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/MeasureControllerIT.java
@@ -44,18 +44,18 @@ class MeasureControllerIT {
     static Measure measure = Measure.Builder.builder().withId(5L)
             .withCreatedBy(User.Builder.builder().withId(1L).withFirstname("Frank").build())
             .withCreatedOn(LocalDateTime.MAX)
-            .withKeyResult(KeyResult.Builder.builder().withId(8L).withBasisValue(12L).withObjective(objective)
-                    .withTargetValue(50L).build())
-            .withValue(30).withChangeInfo("ChangeInfo").withInitiatives("Initiatives").build();
+            .withKeyResult(KeyResult.Builder.builder().withId(8L).withBasisValue(12D).withObjective(objective)
+                    .withTargetValue(50D).build())
+            .withValue(30D).withChangeInfo("ChangeInfo").withInitiatives("Initiatives").build();
     static Measure anotherMeasure = Measure.Builder.builder().withId(4L)
             .withCreatedBy(User.Builder.builder().withId(2L).withFirstname("Robert").build())
             .withCreatedOn(LocalDateTime.MAX)
-            .withKeyResult(KeyResult.Builder.builder().withId(9L).withBasisValue(0L).withTargetValue(100L).build())
-            .withValue(35).withChangeInfo("ChangeInfo").build();
-    static MeasureDto measureDto = new MeasureDto(5L, 8L, 30, "changeInfo", "Initiatives", 1L, LocalDateTime.MAX,
+            .withKeyResult(KeyResult.Builder.builder().withId(9L).withBasisValue(0D).withTargetValue(100D).build())
+            .withValue(35D).withChangeInfo("ChangeInfo").build();
+    static MeasureDto measureDto = new MeasureDto(5L, 8L, 30D, "changeInfo", "Initiatives", 1L, LocalDateTime.MAX,
             Instant.parse("2022-08-12T01:01:00.00Z"));
-    static MeasureDto anotherMeasureDto = new MeasureDto(4L, 9L, 35, "changeInfo", "Initiatives", 2L, LocalDateTime.MAX,
-            Instant.parse("2022-08-12T01:01:00.00Z"));
+    static MeasureDto anotherMeasureDto = new MeasureDto(4L, 9L, 35D, "changeInfo", "Initiatives", 2L,
+            LocalDateTime.MAX, Instant.parse("2022-08-12T01:01:00.00Z"));
     static List<Measure> measureList = Arrays.asList(measure, anotherMeasure);
 
     @Autowired
@@ -81,11 +81,11 @@ class MeasureControllerIT {
         mvc.perform(get("/api/v1/measures").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andExpect(jsonPath("$", Matchers.hasSize(2)))
                 .andExpect(jsonPath("$[0].id", Is.is(5))).andExpect(jsonPath("$[0].keyResultId", Is.is(8)))
-                .andExpect(jsonPath("$[0].value", Is.is(30)))
+                .andExpect(jsonPath("$[0].value", Is.is(30D)))
                 .andExpect(jsonPath("$[0].changeInfo", Is.is("changeInfo")))
                 .andExpect(jsonPath("$[0].initiatives", Is.is("Initiatives")))
                 .andExpect(jsonPath("$[0].createdById", Is.is(1))).andExpect(jsonPath("$[1].id", Is.is(4)))
-                .andExpect(jsonPath("$[1].keyResultId", Is.is(9))).andExpect(jsonPath("$[1].value", Is.is(35)))
+                .andExpect(jsonPath("$[1].keyResultId", Is.is(9))).andExpect(jsonPath("$[1].value", Is.is(35D)))
                 .andExpect(jsonPath("$[1].changeInfo", Is.is("changeInfo")))
                 .andExpect(jsonPath("$[1].measureDate", Is.is("2022-08-12T01:01:00Z")))
                 .andExpect(jsonPath("$[1].createdById", Is.is(2)));
@@ -101,7 +101,7 @@ class MeasureControllerIT {
 
     @Test
     void shouldReturnMeasureWhenCreatingNewMeasure() throws Exception {
-        MeasureDto testMeasure = new MeasureDto(5L, 5L, 30, "changeInfo", "initiatives", 1L, LocalDateTime.now(),
+        MeasureDto testMeasure = new MeasureDto(5L, 5L, 30D, "changeInfo", "initiatives", 1L, LocalDateTime.now(),
                 Instant.parse("2022-08-12T01:01:00.00Z"));
 
         BDDMockito.given(measureService.saveMeasure(any())).willReturn(measure);
@@ -111,7 +111,7 @@ class MeasureControllerIT {
         mvc.perform(post("/api/v1/measures").contentType(MediaType.APPLICATION_JSON).content(
                 "{\"keyResultId\": 5 , \"value\": 30, \"changeInfo\": \"changeInfo\", \"initiatives \": \"initiatives\", \"createdById \": 1, \"measureDate \": \"2022-08-12T01:01:00\"}"))
                 .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()).andExpect(jsonPath("$.id", Is.is(5)))
-                .andExpect(jsonPath("$.keyResultId", Is.is(5))).andExpect(jsonPath("$.value", Is.is(30)))
+                .andExpect(jsonPath("$.keyResultId", Is.is(5))).andExpect(jsonPath("$.value", Is.is(30D)))
                 .andExpect(jsonPath("$.changeInfo", Is.is("changeInfo")));
     }
 
@@ -127,7 +127,7 @@ class MeasureControllerIT {
 
     @Test
     void shouldReturnCorrectMeasure() throws Exception {
-        MeasureDto testMeasure = new MeasureDto(5L, 5L, 30, "changeInfo", "initiatives", 1L, LocalDateTime.now(),
+        MeasureDto testMeasure = new MeasureDto(5L, 5L, 30D, "changeInfo", "initiatives", 1L, LocalDateTime.now(),
                 Instant.parse("2022-08-12T01:01:00.00Z"));
         BDDMockito.given(measureService.updateMeasure(anyLong(), any())).willReturn(measure);
         BDDMockito.given(measureMapper.toDto(any())).willReturn(testMeasure);
@@ -136,7 +136,7 @@ class MeasureControllerIT {
         mvc.perform(put("/api/v1/measures/1").contentType(MediaType.APPLICATION_JSON)
                 .content("{\"keyResultId\": 1, \"value\": 30, \"changeInfo\": "
                         + "\"changeInfo\", \"initiatives \": \"initiatives\", \"createdById \": null, \"measureDate \": null}"))
-                .andExpect(MockMvcResultMatchers.status().isOk()).andExpect(jsonPath("$.value", Is.is(30)))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andExpect(jsonPath("$.value", Is.is(30D)))
                 .andExpect(jsonPath("$.createdById", Is.is(1)))
                 .andExpect(jsonPath("$.measureDate", Is.is("2022-08-12T01:01:00Z")))
                 .andExpect(jsonPath("$.initiatives", Is.is("initiatives")));

--- a/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/ObjectiveControllerIT.java
@@ -58,19 +58,19 @@ class ObjectiveControllerIT {
             "GJ 22/23-Q2", "This is a description", 20L);
     static KeyResult keyResult1 = KeyResult.Builder.builder().withId(5L).withTitle("Keyresult 1").build();
     static KeyResult keyResult2 = KeyResult.Builder.builder().withId(7L).withTitle("Keyresult 2").build();
-    static MeasureDto measure1Dto = new MeasureDto(1L, 5L, 10, "foo", "boo", 1L, null,
+    static MeasureDto measure1Dto = new MeasureDto(1L, 5L, 10D, "foo", "boo", 1L, null,
             Instant.parse("2022-08-12T01:01:00.00Z"));
-    static MeasureDto measure2Dto = new MeasureDto(2L, 7L, 10, "foo", "boo", 1L, null,
+    static MeasureDto measure2Dto = new MeasureDto(2L, 7L, 10D, "foo", "boo", 1L, null,
             Instant.parse("2022-08-12T01:01:00.00Z"));
     static List<KeyResultMeasureDto> keyResultsMeasureList = List.of(
             new KeyResultMeasureDto(5L, 1L, "Keyresult 1", "Description", 1L, "Paco", "Egiman",
-                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, measure1Dto, 0L),
+                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20D, 100D, measure1Dto, 0L),
             new KeyResultMeasureDto(7L, 1L, "Keyresult 2", "Description", 1L, "Robin", "Papier",
-                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, measure2Dto, 0L));
+                    ExpectedEvolution.CONSTANT, Unit.PERCENT, 20D, 100D, measure2Dto, 0L));
     static KeyResultDto keyresult1Dto = new KeyResultDto(5L, 1L, "Keyresult 1", "Description", 1L, "Alice",
-            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, 0L);
+            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20D, 100D, 0L);
     static KeyResultDto keyresult2Dto = new KeyResultDto(7L, 1L, "Keyresult 2", "Description", 1L, "Alice",
-            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, 0L);
+            "Wunderland", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20D, 100D, 0L);
 
     @Autowired
     private MockMvc mvc;

--- a/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
@@ -115,7 +115,7 @@ class KeyResultServiceTest {
         this.keyResultService.createKeyResult(this.keyResultBinary);
 
         KeyResult changedKeyResult = KeyResult.Builder.builder().withId(5L).withUnit(Unit.BINARY)
-                .withTitle("Keyresult 1").withObjective(this.objective).withBasisValue(0L).withTargetValue(1L)
+                .withTitle("Keyresult 1").withObjective(this.objective).withBasisValue(0D).withTargetValue(1D)
                 .withOwner(this.user).build();
         verify(this.keyResultRepository, times(1)).save(changedKeyResult);
     }

--- a/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/KeyResultServiceTest.java
@@ -185,8 +185,8 @@ class KeyResultServiceTest {
         when(measureRepository.findLastMeasuresOfKeyresults(any())).thenReturn(measures);
         when(keyResultRepository.findByObjective(any())).thenReturn(keyResults);
         when(keyResultMeasureMapper.toDto(keyResult, measure1)).thenReturn(new KeyResultMeasureDto(5L, 1L,
-                "Keyresult 1", "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L,
-                new MeasureDto(1L, 1L, 10, "", "", 1L, null, null), 0L));
+                "Keyresult 1", "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20D, 100D,
+                new MeasureDto(1L, 1L, 10D, "", "", 1L, null, null), 0L));
 
         List<KeyResultMeasureDto> keyResultList = keyResultService.getAllKeyResultsByObjectiveWithMeasure(1L);
 
@@ -202,7 +202,7 @@ class KeyResultServiceTest {
         when(measureRepository.findLastMeasuresOfKeyresults(any())).thenReturn(measures);
         when(keyResultRepository.findByObjective(any())).thenReturn(keyResults);
         when(keyResultMeasureMapper.toDto(any(), any())).thenReturn(new KeyResultMeasureDto(5L, 1L, "Keyresult 1",
-                "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20L, 100L, null, 0L));
+                "Description", 1L, "Paco", "Egiman", ExpectedEvolution.CONSTANT, Unit.PERCENT, 20D, 100D, null, 0L));
 
         List<KeyResultMeasureDto> keyResultList = keyResultService.getAllKeyResultsByObjectiveWithMeasure(1L);
 

--- a/backend/src/test/java/ch/puzzle/okr/service/MeasureServiceTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/service/MeasureServiceTest.java
@@ -45,9 +45,9 @@ class MeasureServiceTest {
         this.measure = Measure.Builder.builder()
                 .withCreatedBy(User.Builder.builder().withId(1L).withFirstname("Frank").build())
                 .withCreatedOn(LocalDateTime.MAX)
-                .withKeyResult(KeyResult.Builder.builder().withId(8L).withBasisValue(12L).withTargetValue(50L)
+                .withKeyResult(KeyResult.Builder.builder().withId(8L).withBasisValue(12D).withTargetValue(50D)
                         .withObjective(Objective.Builder.builder().withId(1L).build()).build())
-                .withValue(30).withChangeInfo("ChangeInfo").withInitiatives("Initiatives")
+                .withValue(30D).withChangeInfo("ChangeInfo").withInitiatives("Initiatives")
                 .withMeasureDate(Instant.parse("2021-11-03T00:00:00.00Z")).build();
         this.falseMeasure = Measure.Builder.builder().withId(3L).build();
     }

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -585,7 +585,7 @@ describe('KeyresultFormComponent', () => {
       expect(component.keyResultForm.valid).toBeTruthy();
     });
 
-    test('should be invalid form if targetValue or basicValue is a double', async () => {
+    test('should be valid form if targetValue or basicValue is a double', async () => {
       //Set Values
       component.keyResultForm.controls['ownerId'].setValue(3);
       component.keyResultForm.controls['title'].setValue('Title');
@@ -594,7 +594,43 @@ describe('KeyresultFormComponent', () => {
       );
       component.keyResultForm.controls['description'].setValue('Description');
       component.keyResultForm.controls['targetValue'].setValue(10.5);
-      component.keyResultForm.controls['basicValue'].setValue(57.897);
+      component.keyResultForm.controls['basicValue'].setValue(57.8);
+
+      //Chose unit and check validation of form
+      const select = await loader.getHarness(
+        MatSelectHarness.with({
+          selector: 'mat-select[formControlName="unit"]',
+        })
+      );
+      await select.open();
+      let bugOption = await select.getOptions({ text: 'ZAHL' });
+      await bugOption[0].click();
+      expect(component.keyResultForm.valid).toBeTruthy();
+    });
+
+    test('should be valid form if targetValue or basicValue is a double and unit is percent', async () => {
+      //Set Values
+      component.keyResultForm.controls['title'].setValue('KeyResult');
+      component.keyResultForm.controls['targetValue'].setValue(50.6);
+      component.keyResultForm.controls['basicValue'].setValue(23.5);
+
+      //Chose unit and check validation of form
+      const select = await loader.getHarness(
+        MatSelectHarness.with({
+          selector: 'mat-select[formControlName="unit"]',
+        })
+      );
+      await select.open();
+      let bugOption = await select.getOptions({ text: 'PROZENT' });
+      await bugOption[0].click();
+      expect(component.keyResultForm.valid).toBeTruthy();
+    });
+
+    test('should be invalid form if targetValue or basicValue have more numbers behind the comma than 1', async () => {
+      //Set Values
+      component.keyResultForm.controls['title'].setValue('KeyResult');
+      component.keyResultForm.controls['targetValue'].setValue(50.667);
+      component.keyResultForm.controls['basicValue'].setValue(23.53);
 
       //Chose unit and check validation of form
       const select = await loader.getHarness(

--- a/frontend/src/app/shared/components/shared/measure-form/measure-form.componentCreate.spec.ts
+++ b/frontend/src/app/shared/components/shared/measure-form/measure-form.componentCreate.spec.ts
@@ -302,7 +302,6 @@ describe('MeasureFormComponent Create', () => {
     it('should save new measure', () => {
       component.measureForm = createMeasureForm;
       fixture.detectChanges();
-      let button = fixture.debugElement.query(By.css('.create-button'));
       expect(component.measureForm.disabled).toEqual(false);
 
       component.save();

--- a/frontend/src/app/shared/components/shared/measure-form/measure-form.componentEdit.spec.ts
+++ b/frontend/src/app/shared/components/shared/measure-form/measure-form.componentEdit.spec.ts
@@ -315,6 +315,16 @@ describe('MeasureFormComponent Edit', () => {
       expect(component.measureForm.get('value')?.valid).toEqual(true);
     });
 
+    it('should be invalid when value has more than one number behind comma', () => {
+      component.measureForm.get('value')?.setValue(33.456);
+      expect(component.measureForm.get('value')?.valid).toEqual(false);
+    });
+
+    it('should be invalid when value is greater than 100 and has numbers behind comma', () => {
+      component.measureForm.get('value')?.setValue(133.456);
+      expect(component.measureForm.get('value')?.valid).toEqual(false);
+    });
+
     it('should have datepicker value', () => {
       const datepicker = fixture.debugElement.query(
         By.css('input[formControlName="measureDate"]')

--- a/frontend/src/app/shared/regexLibrary.ts
+++ b/frontend/src/app/shared/regexLibrary.ts
@@ -1,2 +1,2 @@
-export const PERCENT_REGEX = '^[0-9][0-9]?$|^100$|^[0-9][0-9]?\\.{1}[0-9]$';
+export const PERCENT_REGEX = '^[0-9][0-9]?(\\.[0-9])?$|^100$';
 export const NUMBER_REGEX = '^[0-9][0-9]*.?[0-9]?$';

--- a/frontend/src/app/shared/regexLibrary.ts
+++ b/frontend/src/app/shared/regexLibrary.ts
@@ -1,2 +1,2 @@
-export const PERCENT_REGEX = '^[0-9][0-9]?$|^100$';
-export const NUMBER_REGEX = '^[0-9][0-9]*$';
+export const PERCENT_REGEX = '^[0-9][0-9]?$|^100$|^[0-9][0-9]?\\.{1}[0-9]$';
+export const NUMBER_REGEX = '^[0-9][0-9]*.?[0-9]?$';


### PR DESCRIPTION
### Was gemacht wurde:
**Backend:**
- KeyResult (targetValue / basicValue) wurden zu double geändert
- Measure (value) wurde zu double geändert
- Tests wurden angepasst

**Frontend:**
- Regex wurde überarbeitet, nun werden auch double Werte akzeptiert (aber nur eine Nachkommastelle)
- Dies beim KeyResult- sowie MeasureForm
- Auch hier wurden die Tests nachgezogen und neue hinzugefügt