### PR TITLE
Feature/143 erwartete entwicklung nicht muss

### DIFF
--- a/backend/src/main/java/ch/puzzle/okr/models/ExpectedEvolution.java
+++ b/backend/src/main/java/ch/puzzle/okr/models/ExpectedEvolution.java
@@ -1,5 +1,5 @@
 package ch.puzzle.okr.models;
 
 public enum ExpectedEvolution {
-    INCREASE, DECREASE, CONSTANT
+    INCREASE, DECREASE, CONSTANT, NONE
 }

--- a/backend/src/main/java/ch/puzzle/okr/models/KeyResult.java
+++ b/backend/src/main/java/ch/puzzle/okr/models/KeyResult.java
@@ -27,6 +27,7 @@ public class KeyResult {
     @ManyToOne
     private User owner;
 
+    @NotNull
     private ExpectedEvolution expectedEvolution;
 
     @NotNull

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
@@ -128,9 +128,6 @@
             >
               {{ "EXPECTED_EVOLUTION." + evolution | translate }}
             </mat-option>
-            <mat-option [value]="null">{{
-              "EXPECTED_EVOLUTION.NONE" | translate
-            }}</mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
@@ -128,6 +128,7 @@
             >
               {{ "EXPECTED_EVOLUTION." + evolution | translate }}
             </mat-option>
+            <mat-option [value]="null"> NONE </mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
@@ -128,7 +128,7 @@
             >
               {{ "EXPECTED_EVOLUTION." + evolution | translate }}
             </mat-option>
-            <mat-option [value]="null"> NONE </mat-option>
+            <mat-option [value]="null">NONE</mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.html
@@ -128,7 +128,9 @@
             >
               {{ "EXPECTED_EVOLUTION." + evolution | translate }}
             </mat-option>
-            <mat-option [value]="null">NONE</mat-option>
+            <mat-option [value]="null">{{
+              "EXPECTED_EVOLUTION.NONE" | translate
+            }}</mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -642,6 +642,7 @@ describe('KeyresultFormComponent', () => {
     test('should be valid form if targetValue or basicValue is a double and unit is percent', async () => {
       //Set Values
       component.keyResultForm.controls['title'].setValue('KeyResult');
+      component.keyResultForm.controls['expectedEvolution'].setValue('NONE');
       component.keyResultForm.controls['targetValue'].setValue(50.6);
       component.keyResultForm.controls['basicValue'].setValue(23.5);
 

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -214,8 +214,6 @@ describe('KeyresultFormComponent', () => {
       expect(component.keyResultForm.valid).toBeFalsy();
     });
 
-    test('should have label for Key Result unit', () => {
-      const unitLabel = fixture.debugElement.query(By.css('.keyresult-unit'));
     test('should set ExpectedEvolution to NONE', async () => {
       const select = await loader.getHarness(
         MatSelectHarness.with({
@@ -227,17 +225,6 @@ describe('KeyresultFormComponent', () => {
       await bugOption[0].click();
       expect(await select.getValueText()).toEqual('');
       expect(component.keyResultForm.valid).toBeTruthy();
-    });
-
-    test('should set Key Result unit in mat select and set it new on item change', async () => {
-      const select = await loader.getHarness(
-        MatSelectHarness.with({
-          selector: 'mat-select[formControlName="unit"]',
-        })
-      );
-      expect(await select.getValueText()).toEqual('PERCENT');
-
-      expect(unitLabel.nativeElement.textContent).toContain('PROZENT');
     });
 
     test('should not have Key Result unit drop down', () => {
@@ -363,6 +350,11 @@ describe('KeyresultFormComponent', () => {
         expect(mockKeyResultService.saveKeyresult).toHaveBeenCalledTimes(1);
       });
     });
+
+    test('should have label for Key Result unit', () => {
+      const unitLabel = fixture.debugElement.query(By.css('.keyresult-unit'));
+      expect(unitLabel.nativeElement.textContent).toContain('PROZENT');
+    });
   });
 
   describe('KeyresultFormComponent Create Key Result', () => {
@@ -423,6 +415,22 @@ describe('KeyresultFormComponent', () => {
       expect(mockObjectiveService.getObjectiveById).toHaveBeenCalledWith(1);
       expect(mockKeyResultService.getKeyResultById).toHaveBeenCalledTimes(0);
       expect(mockKeyResultService.getInitKeyResult).toHaveBeenCalled();
+    });
+
+    test('should set Key Result unit in mat select and set it new on item change', async () => {
+      const select = await loader.getHarness(
+        MatSelectHarness.with({
+          selector: 'mat-select[formControlName="unit"]',
+        })
+      );
+      expect(await select.getValueText()).toEqual('');
+
+      await select.open();
+      const bugOption = await select.getOptions({ text: 'PROZENT' });
+      await bugOption[0].click();
+      expect(component.keyResultForm.controls['unit'].value).toContain(
+        'PERCENT'
+      );
     });
 
     test('should set init Key Result', () => {

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -223,7 +223,11 @@ describe('KeyresultFormComponent', () => {
       await select.open();
       const bugOption = await select.getOptions({ text: 'NONE' });
       await bugOption[0].click();
+
       expect(await select.getValueText()).toEqual('');
+      expect(
+        component.keyResultForm.controls['expectedEvolution'].value
+      ).toBeNull();
       expect(component.keyResultForm.valid).toBeTruthy();
     });
 
@@ -549,25 +553,6 @@ describe('KeyresultFormComponent', () => {
       expect(await select.getValueText()).toEqual('VERMINDERT');
       expect(await select.isDisabled()).toBeFalsy();
       expect(await select.isOpen()).toBeFalsy();
-    });
-    //Test funktioniert noch nicht
-    xtest('should be possible to unselect expected Evolution option', async () => {
-      const select = await loader.getHarness(
-        MatSelectHarness.with({
-          selector: 'mat-select[formControlName="expectedEvolution"]',
-        })
-      );
-      expect(await select.getValueText()).toEqual('');
-
-      await select.open();
-      const bugOption = await select.getOptions({ text: 'DECREASE' });
-      await bugOption[0].click();
-
-      expect(await select.getValueText()).toEqual('DECREASE');
-
-      const noneOption = await select.getOptions({ text: 'NONE' });
-      await noneOption[0].click();
-      expect(await select.getValueText()).toEqual('NONE');
     });
 
     test('should be possible to set Key Result owner in mat select', async () => {

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -216,6 +216,26 @@ describe('KeyresultFormComponent', () => {
 
     test('should have label for Key Result unit', () => {
       const unitLabel = fixture.debugElement.query(By.css('.keyresult-unit'));
+    test('should set ExpectedEvolution to NONE', async () => {
+      const select = await loader.getHarness(
+        MatSelectHarness.with({
+          selector: 'mat-select[formControlName="expectedEvolution"]',
+        })
+      );
+      await select.open();
+      const bugOption = await select.getOptions({ text: 'NONE' });
+      await bugOption[0].click();
+      expect(await select.getValueText()).toEqual('');
+      expect(component.keyResultForm.valid).toBeTruthy();
+    });
+
+    test('should set Key Result unit in mat select and set it new on item change', async () => {
+      const select = await loader.getHarness(
+        MatSelectHarness.with({
+          selector: 'mat-select[formControlName="unit"]',
+        })
+      );
+      expect(await select.getValueText()).toEqual('PERCENT');
 
       expect(unitLabel.nativeElement.textContent).toContain('PROZENT');
     });

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -221,7 +221,7 @@ describe('KeyresultFormComponent', () => {
         })
       );
       await select.open();
-      const bugOption = await select.getOptions({ text: 'NONE' });
+      const bugOption = await select.getOptions({ text: 'KEINE' });
       await bugOption[0].click();
 
       expect(await select.getValueText()).toEqual('');

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -221,13 +221,13 @@ describe('KeyresultFormComponent', () => {
         })
       );
       await select.open();
-      const bugOption = await select.getOptions({ text: 'KEINE' });
+      const bugOption = await select.getOptions({ text: 'Keine' });
       await bugOption[0].click();
 
-      expect(await select.getValueText()).toEqual('');
+      expect(await select.getValueText()).toEqual('Keine');
       expect(
         component.keyResultForm.controls['expectedEvolution'].value
-      ).toBeNull();
+      ).toEqual('NONE');
       expect(component.keyResultForm.valid).toBeTruthy();
     });
 
@@ -244,13 +244,13 @@ describe('KeyresultFormComponent', () => {
           selector: 'mat-select[formControlName="expectedEvolution"]',
         })
       );
-      expect(await select.getValueText()).toEqual('ERHÖHT');
+      expect(await select.getValueText()).toEqual('Erhöht');
 
       await select.open();
-      const bugOption = await select.getOptions({ text: 'VERMINDERT' });
+      const bugOption = await select.getOptions({ text: 'Vermindert' });
       await bugOption[0].click();
 
-      expect(await select.getValueText()).toEqual('VERMINDERT');
+      expect(await select.getValueText()).toEqual('Vermindert');
       expect(await select.isDisabled()).toBeFalsy();
       expect(await select.isOpen()).toBeFalsy();
     });
@@ -357,7 +357,7 @@ describe('KeyresultFormComponent', () => {
 
     test('should have label for Key Result unit', () => {
       const unitLabel = fixture.debugElement.query(By.css('.keyresult-unit'));
-      expect(unitLabel.nativeElement.textContent).toContain('PROZENT');
+      expect(unitLabel.nativeElement.textContent).toContain('Prozent');
     });
   });
 
@@ -430,7 +430,7 @@ describe('KeyresultFormComponent', () => {
       expect(await select.getValueText()).toEqual('');
 
       await select.open();
-      const bugOption = await select.getOptions({ text: 'PROZENT' });
+      const bugOption = await select.getOptions({ text: 'Prozent' });
       await bugOption[0].click();
       expect(component.keyResultForm.controls['unit'].value).toContain(
         'PERCENT'
@@ -530,10 +530,10 @@ describe('KeyresultFormComponent', () => {
       );
 
       await select.open();
-      const bugOption = await select.getOptions({ text: 'ZAHL' });
+      const bugOption = await select.getOptions({ text: 'Zahl' });
       await bugOption[0].click();
 
-      expect(await select.getValueText()).toEqual('ZAHL');
+      expect(await select.getValueText()).toEqual('Zahl');
       expect(await select.isDisabled()).toBeFalsy();
       expect(await select.isOpen()).toBeFalsy();
     });
@@ -547,10 +547,10 @@ describe('KeyresultFormComponent', () => {
       expect(await select.getValueText()).toEqual('');
 
       await select.open();
-      const bugOption = await select.getOptions({ text: 'VERMINDERT' });
+      const bugOption = await select.getOptions({ text: 'Vermindert' });
       await bugOption[0].click();
 
-      expect(await select.getValueText()).toEqual('VERMINDERT');
+      expect(await select.getValueText()).toEqual('Vermindert');
       expect(await select.isDisabled()).toBeFalsy();
       expect(await select.isOpen()).toBeFalsy();
     });
@@ -605,13 +605,13 @@ describe('KeyresultFormComponent', () => {
         })
       );
       await select.open();
-      let bugOption = await select.getOptions({ text: 'PROZENT' });
+      let bugOption = await select.getOptions({ text: 'Prozent' });
       await bugOption[0].click();
       expect(component.keyResultForm.valid).toBeFalsy();
 
       //Change unit to binary which accepts every number
       await select.open();
-      bugOption = await select.getOptions({ text: 'BINÄR' });
+      bugOption = await select.getOptions({ text: 'Binär' });
       await bugOption[0].click();
       expect(component.keyResultForm.valid).toBeTruthy();
     });
@@ -634,7 +634,7 @@ describe('KeyresultFormComponent', () => {
         })
       );
       await select.open();
-      let bugOption = await select.getOptions({ text: 'ZAHL' });
+      let bugOption = await select.getOptions({ text: 'Zahl' });
       await bugOption[0].click();
       expect(component.keyResultForm.valid).toBeTruthy();
     });
@@ -652,7 +652,7 @@ describe('KeyresultFormComponent', () => {
         })
       );
       await select.open();
-      let bugOption = await select.getOptions({ text: 'PROZENT' });
+      let bugOption = await select.getOptions({ text: 'Prozent' });
       await bugOption[0].click();
       expect(component.keyResultForm.valid).toBeTruthy();
     });
@@ -670,7 +670,7 @@ describe('KeyresultFormComponent', () => {
         })
       );
       await select.open();
-      let bugOption = await select.getOptions({ text: 'ZAHL' });
+      let bugOption = await select.getOptions({ text: 'Zahl' });
       await bugOption[0].click();
       expect(component.keyResultForm.valid).toBeFalsy();
     });

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.spec.ts
@@ -522,6 +522,25 @@ describe('KeyresultFormComponent', () => {
       expect(await select.isDisabled()).toBeFalsy();
       expect(await select.isOpen()).toBeFalsy();
     });
+    //Test funktioniert noch nicht
+    xtest('should be possible to unselect expected Evolution option', async () => {
+      const select = await loader.getHarness(
+        MatSelectHarness.with({
+          selector: 'mat-select[formControlName="expectedEvolution"]',
+        })
+      );
+      expect(await select.getValueText()).toEqual('');
+
+      await select.open();
+      const bugOption = await select.getOptions({ text: 'DECREASE' });
+      await bugOption[0].click();
+
+      expect(await select.getValueText()).toEqual('DECREASE');
+
+      const noneOption = await select.getOptions({ text: 'NONE' });
+      await noneOption[0].click();
+      expect(await select.getValueText()).toEqual('NONE');
+    });
 
     test('should be possible to set Key Result owner in mat select', async () => {
       const select = await loader.getHarness(

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.ts
@@ -49,7 +49,12 @@ export class KeyresultFormComponent implements OnInit {
   public users$!: Observable<User[]>;
   public objective$!: Observable<Objective>;
   public unit$: string[] = ['PERCENT', 'CHF', 'NUMBER', 'BINARY'];
-  public expectedEvolution$: string[] = ['INCREASE', 'DECREASE', 'CONSTANT'];
+  public expectedEvolution$: string[] = [
+    'INCREASE',
+    'DECREASE',
+    'CONSTANT',
+    'NONE',
+  ];
   public create!: boolean;
 
   constructor(

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.ts
@@ -33,7 +33,7 @@ export class KeyresultFormComponent implements OnInit {
       Validators.maxLength(250),
     ]),
     unit: new FormControl<string>('', [Validators.required]),
-    expectedEvolution: new FormControl<string>(''),
+    expectedEvolution: new FormControl<string>('', [Validators.required]),
     basicValue: new FormControl<number>({ value: 0, disabled: true }, [
       Validators.required,
     ]),

--- a/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.ts
+++ b/frontend/src/app/shared/components/shared/keyresult-form/keyresult-form.component.ts
@@ -94,7 +94,6 @@ export class KeyresultFormComponent implements OnInit {
         }
       })
     );
-
     this.keyresult$.subscribe((keyresult) => {
       const {
         id,

--- a/frontend/src/app/shared/components/shared/measure-form/measure-form.componentCreate.spec.ts
+++ b/frontend/src/app/shared/components/shared/measure-form/measure-form.componentCreate.spec.ts
@@ -276,7 +276,7 @@ describe('MeasureFormComponent Create', () => {
 
     test('should have Key Result unit', () => {
       const unit = fixture.debugElement.query(By.css('.unit-label'));
-      expect(unit.nativeElement.textContent).toEqual('PROZENT');
+      expect(unit.nativeElement.textContent).toEqual('Prozent');
     });
 
     test('should update measureDate with datepicker', async () => {

--- a/frontend/src/app/shared/components/shared/measure-form/measure-form.componentEdit.spec.ts
+++ b/frontend/src/app/shared/components/shared/measure-form/measure-form.componentEdit.spec.ts
@@ -296,12 +296,12 @@ describe('MeasureFormComponent Edit', () => {
 
     test('should have Key Result unit', () => {
       const unit = fixture.debugElement.query(By.css('.unit-label'));
-      expect(unit.nativeElement.textContent).toEqual('PROZENT');
+      expect(unit.nativeElement.textContent).toEqual('Prozent');
     });
 
     test('should be invalid when not matching pattern of Key Result unit', () => {
       const unit = fixture.debugElement.query(By.css('.unit-label'));
-      expect(unit.nativeElement.textContent).toEqual('PROZENT');
+      expect(unit.nativeElement.textContent).toEqual('Prozent');
       component.measureForm.get('value')?.setValue(333);
       expect(component.measureForm.get('value')?.valid).toEqual(false);
 

--- a/frontend/src/app/shared/components/shared/measure-form/measure-form.componentEditBinary.spec.ts
+++ b/frontend/src/app/shared/components/shared/measure-form/measure-form.componentEditBinary.spec.ts
@@ -365,7 +365,7 @@ describe('MeasureFormComponent Edit Binary', () => {
 
     test('should have Key Result unit in html', () => {
       const unit = fixture.debugElement.query(By.css('.unit-label'));
-      expect(unit.nativeElement.textContent).toEqual('BINÄR');
+      expect(unit.nativeElement.textContent).toEqual('Binär');
     });
 
     xtest('should save edited measure', () => {

--- a/frontend/src/app/shared/services/key-result.service.ts
+++ b/frontend/src/app/shared/services/key-result.service.ts
@@ -65,8 +65,8 @@ export class KeyResultService {
       ownerId: 0,
       ownerLastname: '',
       ownerFirstname: '',
-      targetValue: 1,
-      basicValue: 1,
+      targetValue: 0,
+      basicValue: 0,
       objectiveId: 1,
       progress: 0,
     };

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -2,7 +2,8 @@
   "EXPECTED_EVOLUTION": {
     "INCREASE": "ERHÖHT",
     "DECREASE": "VERMINDERT",
-    "CONSTANT": "KONSTANT"
+    "CONSTANT": "KONSTANT",
+    "NONE": "KEINE"
   },
   "UNIT": {
     "PERCENT": "PROZENT",

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -1,14 +1,14 @@
 {
   "EXPECTED_EVOLUTION": {
-    "INCREASE": "ERHÖHT",
-    "DECREASE": "VERMINDERT",
-    "CONSTANT": "KONSTANT",
-    "NONE": "KEINE"
+    "INCREASE": "Erhöht",
+    "DECREASE": "Vermindert",
+    "CONSTANT": "Konstant",
+    "NONE": "Keine"
   },
   "UNIT": {
-    "PERCENT": "PROZENT",
+    "PERCENT": "Prozent",
     "CHF": "CHF",
-    "NUMBER": "ZAHL",
-    "BINARY": "BINÄR"
+    "NUMBER": "Zahl",
+    "BINARY": "Binär"
   }
 }


### PR DESCRIPTION
### Was gemacht wurde: 

**Backend:**
- Der @NotNull Validator auf der ExpectedEvolution wurde entfernt
- Die Tests wurden dementsprechend abgeändert (falls dies nötig war)

**Frontend:**
- Die Validators im Frontend Form (KeyResultForm) wurden gelöscht
- Eine zusätzliche Option NONE wurde hinzugefügt um keine ExpectedEvolution zu wählen
- Diese zusätzliche Option wurde im de.json übersetzt