### PR TITLE
fix border right if keyresult is newly loaded

### DIFF
--- a/frontend/src/app/keyresult-detail/keyresult-detail.component.scss
+++ b/frontend/src/app/keyresult-detail/keyresult-detail.component.scss
@@ -15,11 +15,11 @@
 }
 
 .scoring-detail {
-  width: 82%;
+  width: 81%;
 }
 
 .confidence-container {
-  width: 18%;
+  width: 19%;
 }
 
 .ordinal-scoring-boxes {

--- a/frontend/src/app/shared/custom/scoring/scoring.component.ts
+++ b/frontend/src/app/shared/custom/scoring/scoring.component.ts
@@ -175,7 +175,7 @@ export class ScoringComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   removeStyleClass() {
-    let classArray: string[] = ['score-red', 'score-green', 'score-yellow', 'score-stretch'];
+    let classArray: string[] = ['score-red', 'score-green', 'score-yellow', 'score-stretch', 'border-right'];
     for (let classToRemove of classArray) {
       this.commitElement?.nativeElement.classList.remove(classToRemove);
       this.targetElement?.nativeElement.classList.remove(classToRemove);

--- a/frontend/src/assets/images/scoring-stars.svg
+++ b/frontend/src/assets/images/scoring-stars.svg
@@ -1,12 +1,12 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g clip-path="url(#clip0_1799_19557)">
-    <rect width="25" height="25" fill="white"/>
-    <rect width="25" height="25" fill="#1E5A96"/>
+<svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_2286_18807)">
+    <rect width="21" height="21" fill="white"/>
+    <rect width="21" height="21" fill="#1E5A96"/>
     <path d="M10.5 3L12.1839 8.18237H17.6329L13.2245 11.3853L14.9084 16.5676L10.5 13.3647L6.09161 16.5676L7.77547 11.3853L3.36708 8.18237H8.81614L10.5 3Z" fill="white"/>
   </g>
   <defs>
-    <clipPath id="clip0_1799_19557">
-      <rect width="25" height="25" fill="white"/>
+    <clipPath id="clip0_2286_18807">
+      <rect width="21" height="21" fill="white"/>
     </clipPath>
   </defs>
 </svg>

--- a/frontend/src/style/styles.scss
+++ b/frontend/src/style/styles.scss
@@ -183,7 +183,7 @@ input[type="text"] {
 .stretch-div {
   width: 100%;
   background-image: url("./../assets/images/scoring-stars.svg");
-  height: 27px;
+  height: 21px;
 }
 
 @media only screen and (max-width: 420px) {

--- a/frontend/src/style/styles.scss
+++ b/frontend/src/style/styles.scss
@@ -184,6 +184,7 @@ input[type="text"] {
   width: 100%;
   background-image: url("./../assets/images/scoring-stars.svg");
   height: 21px;
+  margin-bottom: 6.5px;
 }
 
 @media only screen and (max-width: 420px) {


### PR DESCRIPTION
Was gemacht wurde:
- Doppelter Border rechts bei Scoring entfernt
- Neues Icon als bei Stretched Wert in Scoring eingefügt