### PR TITLE
upgrade/spring-fix-swagger-documentation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,8 +53,8 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.7.0</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>


### PR DESCRIPTION
Was gemacht wurde:
- Dependency ausgewechselt um die Swagger Dokumentation erneut anzuzeigen