### PR TITLE
Feature/1185 vorarbeiten kommentar anzeigen

### DIFF
--- a/backend/src/main/java/ch/puzzle/okr/dto/CompletedDto.java
+++ b/backend/src/main/java/ch/puzzle/okr/dto/CompletedDto.java
@@ -1,6 +1,4 @@
 package ch.puzzle.okr.dto;
 
-import ch.puzzle.okr.models.Objective;
-
-public record CompletedDto(Long id, Objective objective, String comment) {
+public record CompletedDto(Long id, ObjectiveDto objective, String comment) {
 }

--- a/backend/src/main/java/ch/puzzle/okr/mapper/CompletedMapper.java
+++ b/backend/src/main/java/ch/puzzle/okr/mapper/CompletedMapper.java
@@ -7,12 +7,24 @@ import org.springframework.stereotype.Component;
 @Component
 public class CompletedMapper {
 
+    private final ObjectiveMapper objectiveMapper;
+
+    public CompletedMapper(ObjectiveMapper objectiveMapper) {
+        this.objectiveMapper = objectiveMapper;
+    }
+
     public CompletedDto toDto(Completed completed) {
-        return new CompletedDto(completed.getId(), completed.getObjective(), completed.getComment());
+        return new CompletedDto( //
+                completed.getId(), //
+                objectiveMapper.toDto(completed.getObjective()), //
+                completed.getComment());
     }
 
     public Completed toCompleted(CompletedDto completedDto) {
-        return Completed.Builder.builder().withId(completedDto.id()).withObjective(completedDto.objective())
-                .withComment(completedDto.comment()).build();
+        return Completed.Builder.builder() //
+                .withId(completedDto.id()) //
+                .withObjective(objectiveMapper.toObjective(completedDto.objective())) //
+                .withComment(completedDto.comment()) //
+                .build();
     }
 }

--- a/backend/src/test/java/ch/puzzle/okr/controller/CompletedControllerIT.java
+++ b/backend/src/test/java/ch/puzzle/okr/controller/CompletedControllerIT.java
@@ -5,8 +5,11 @@ import ch.puzzle.okr.mapper.CompletedMapper;
 import ch.puzzle.okr.models.Completed;
 import ch.puzzle.okr.models.Objective;
 import ch.puzzle.okr.service.authorization.CompletedAuthorizationService;
+import ch.puzzle.okr.test.dto.builder.CompletedDtoBuilder;
+import ch.puzzle.okr.test.dto.builder.ObjectiveDtoBuilder;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
@@ -34,24 +37,41 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(CompletedController.class)
 class CompletedControllerIT {
-    public static final String SUCCESSFUL_CREATE_BODY = """
+    private static final long COMPLETED_ID = 22L;
+    private static final int COMPLETED_ID_AS_INT = (int) COMPLETED_ID;
+    private static final long OBJECTIVE_ID = 3L;
+    private static final int OBJECTIVE_ID_AS_INT = (int) OBJECTIVE_ID;
+    private static final String COMPLETED_COMMENT = "Wir haben es gut geschafft";
+
+    private static final String SUCCESSFUL_CREATE_BODY = """
             {
                 "id":null,
-                "objectiveId":3,
-                "comment":"Wir haben es gut geschafft"
+                "objectiveId":%d,
+                "comment":"%s"
             }
-            """;
+            """.formatted(OBJECTIVE_ID, COMPLETED_COMMENT);
+
     @MockBean
     CompletedAuthorizationService completedAuthorizationService;
     @MockBean
     private CompletedMapper completedMapper;
-    private static final String WELL_DONE = "Wir haben es gut geschafft";
 
-    Completed successfulCompleted = Completed.Builder.builder().withId(1L)
-            .withObjective(Objective.Builder.builder().withId(3L).withTitle("Gute Lernende").build())
-            .withComment(WELL_DONE).build();
-    CompletedDto completedDto = new CompletedDto(22L,
-            Objective.Builder.builder().withId(3L).withTitle("Gute Lernende").build(), WELL_DONE);
+    private final Completed successfulCompleted = Completed.Builder.builder() //
+            .withId(COMPLETED_ID) //
+            .withObjective(Objective.Builder.builder() //
+                    .withId(OBJECTIVE_ID) //
+                    .build()) //
+            .withComment(COMPLETED_COMMENT) //
+            .build();
+
+    private final CompletedDto completedDto = CompletedDtoBuilder.builder() //
+            .withId(COMPLETED_ID) //
+            .withComment(COMPLETED_COMMENT) //
+            .withObjectiveDto(ObjectiveDtoBuilder.builder() //
+                    .withId(OBJECTIVE_ID) //
+                    .build()) //
+            .build();
+
     String baseUrl = "/api/v2/completed";
     @Autowired
     private MockMvc mvc;
@@ -62,25 +82,32 @@ class CompletedControllerIT {
         BDDMockito.given(completedMapper.toCompleted(any())).willReturn(successfulCompleted);
     }
 
+    @DisplayName("create() should create complete")
     @Test
-    void createSuccessfulCompleted() throws Exception {
+    void createShouldCreateCompleted() throws Exception {
         BDDMockito.given(this.completedAuthorizationService.createCompleted(any())).willReturn(successfulCompleted);
 
-        mvc.perform(post(baseUrl).content(SUCCESSFUL_CREATE_BODY).contentType(MediaType.APPLICATION_JSON)
-                .with(SecurityMockMvcRequestPostProcessors.csrf()))
-                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
-                .andExpect(jsonPath(JSON_PATH_ID, Is.is(22))).andExpect(jsonPath("$.objective.id", Is.is(3)))
-                .andExpect(jsonPath("$.comment", Is.is(WELL_DONE)));
+        mvc.perform(post(baseUrl) //
+                .content(SUCCESSFUL_CREATE_BODY) //
+                .contentType(MediaType.APPLICATION_JSON) //
+                .with(SecurityMockMvcRequestPostProcessors.csrf())) //
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()) //
+                .andExpect(jsonPath(JSON_PATH_ID, Is.is(COMPLETED_ID_AS_INT))) //
+                .andExpect(jsonPath("$.id", Is.is(COMPLETED_ID_AS_INT))) //
+                .andExpect(jsonPath("$.objective.id", Is.is(OBJECTIVE_ID_AS_INT))) //
+                .andExpect(jsonPath("$.comment", Is.is(COMPLETED_COMMENT)));
     }
 
+    @DisplayName("delete() should delete Completed")
     @Test
-    void shouldDeleteCompleted() throws Exception {
+    void deleteShouldDeleteCompleted() throws Exception {
         mvc.perform(delete("/api/v2/completed/1").with(SecurityMockMvcRequestPostProcessors.csrf()))
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
+    @DisplayName("delete() should throw exception when Completed with id cant be found")
     @Test
-    void throwExceptionWhenCompletedWithIdCantBeFoundWhileDeleting() throws Exception {
+    void deleteShouldThrowExceptionWhenCompletedWithIdCantBeFound() throws Exception {
         doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Completed not found"))
                 .when(completedAuthorizationService).deleteCompletedByObjectiveId(anyLong());
 

--- a/backend/src/test/java/ch/puzzle/okr/mapper/CompletedMapperTest.java
+++ b/backend/src/test/java/ch/puzzle/okr/mapper/CompletedMapperTest.java
@@ -3,10 +3,18 @@ package ch.puzzle.okr.mapper;
 import ch.puzzle.okr.dto.CompletedDto;
 import ch.puzzle.okr.models.Completed;
 import ch.puzzle.okr.models.Objective;
+import ch.puzzle.okr.models.Quarter;
+import ch.puzzle.okr.models.Team;
+import ch.puzzle.okr.service.business.QuarterBusinessService;
+import ch.puzzle.okr.service.business.TeamBusinessService;
+import ch.puzzle.okr.test.dto.builder.CompletedDtoBuilder;
+import ch.puzzle.okr.test.dto.builder.ObjectiveDtoBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,27 +22,45 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 public class CompletedMapperTest {
+    private static final long COMPLETED_ID = 0L;
+    private static final String COMPLETED_COMMENT = "some comment";
+    private static final long OBJECTIVE_ID = 23L;
 
-    private static final long ID = 0L;
-    private static final String COMMENT = "some comment";
+    private static final long NOT_USED_LONG = 1L;
+
+    private CompletedMapper completedMapper;
 
     @InjectMocks
-    private CompletedMapper completedMapper;
+    private ObjectiveMapper objectiveMapper;
+
+    @Mock
+    private TeamBusinessService teamBusinessService;
+
+    @Mock
+    private QuarterBusinessService quarterBusinessService;
+
+    @BeforeEach
+    void setUp() {
+        objectiveMapper = new ObjectiveMapper(teamBusinessService, quarterBusinessService);
+        completedMapper = new CompletedMapper(objectiveMapper);
+    }
 
     @DisplayName("toDo() should map Completed to Dto")
     @Test
     void toDtoShouldMapCompletedToDto() {
         // arrange
-        Objective objective = Objective.Builder.builder().withId(23L).build();
-
-        Completed completed = Completed.Builder.builder() //
-                .withId(ID) //
-                .withComment(COMMENT) //
-                .withObjective(objective) //
+        var completed = Completed.Builder.builder() //
+                .withId(COMPLETED_ID) //
+                .withComment(COMPLETED_COMMENT) //
+                .withObjective(Objective.Builder.builder() //
+                        .withId(OBJECTIVE_ID)//
+                        .withTeam(Team.Builder.builder().withId(NOT_USED_LONG).build()) //
+                        .withQuarter(Quarter.Builder.builder().withId(NOT_USED_LONG).build()) //
+                        .build()) //
                 .build();
 
         // act
-        CompletedDto completedDto = completedMapper.toDto(completed);
+        var completedDto = completedMapper.toDto(completed);
 
         // assert
         assertNotNull(completedDto);
@@ -44,18 +70,18 @@ public class CompletedMapperTest {
     private void assertCompletedDto(Completed expected, CompletedDto actual) {
         assertEquals(expected.getId(), actual.id());
         assertEquals(expected.getComment(), actual.comment());
-        assertEquals(expected.getObjective().getId(), actual.objective().getId());
+        assertEquals(expected.getObjective().getId(), actual.objective().id());
     }
 
     @DisplayName("toCompleted() should map Dto to Completed")
     @Test
     void toCompletedShouldMapDtoToCompleted() {
         // arrange
-        Objective objective = Objective.Builder.builder().withId(23L).build();
-        CompletedDto completedDto = new CompletedDto(ID, objective, COMMENT);
+        var completedDto = CompletedDtoBuilder.builder().withId(COMPLETED_ID).withComment(COMPLETED_COMMENT)
+                .withObjectiveDto(ObjectiveDtoBuilder.builder().withId(OBJECTIVE_ID).build()).build();
 
         // act
-        Completed completed = completedMapper.toCompleted(completedDto);
+        var completed = completedMapper.toCompleted(completedDto);
 
         // assert
         assertNotNull(completed);
@@ -65,7 +91,7 @@ public class CompletedMapperTest {
     private void assertCompleted(CompletedDto expected, Completed actual) {
         assertEquals(expected.id(), actual.getId());
         assertEquals(expected.comment(), actual.getComment());
-        assertEquals(expected.objective().getId(), actual.getObjective().getId());
+        assertEquals(expected.objective().id(), actual.getObjective().getId());
     }
 
 }

--- a/backend/src/test/java/ch/puzzle/okr/test/dto/builder/CompletedDtoBuilder.java
+++ b/backend/src/test/java/ch/puzzle/okr/test/dto/builder/CompletedDtoBuilder.java
@@ -1,0 +1,36 @@
+package ch.puzzle.okr.test.dto.builder;
+
+import ch.puzzle.okr.dto.CompletedDto;
+import ch.puzzle.okr.dto.ObjectiveDto;
+
+public class CompletedDtoBuilder {
+    private Long id;
+    private ObjectiveDto objective;
+    private String comment;
+
+    private CompletedDtoBuilder() {
+    }
+
+    public static CompletedDtoBuilder builder() {
+        return new CompletedDtoBuilder();
+    }
+
+    public CompletedDtoBuilder withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public CompletedDtoBuilder withObjectiveDto(ObjectiveDto objective) {
+        this.objective = objective;
+        return this;
+    }
+
+    public CompletedDtoBuilder withComment(String comment) {
+        this.comment = comment;
+        return this;
+    }
+
+    public CompletedDto build() {
+        return new CompletedDto(id, objective, comment);
+    }
+}

--- a/backend/src/test/java/ch/puzzle/okr/test/dto/builder/ObjectiveDtoBuilder.java
+++ b/backend/src/test/java/ch/puzzle/okr/test/dto/builder/ObjectiveDtoBuilder.java
@@ -1,0 +1,88 @@
+package ch.puzzle.okr.test.dto.builder;
+
+import ch.puzzle.okr.dto.ObjectiveDto;
+import ch.puzzle.okr.models.State;
+
+import java.time.LocalDateTime;
+
+public class ObjectiveDtoBuilder {
+    private Long id;
+    private int version;
+    private String title;
+    private Long teamId;
+    private Long quarterId;
+    private String quarterLabel;
+    private String description;
+    private State state;
+    private LocalDateTime createdOn;
+    private LocalDateTime modifiedOn;
+    private boolean writeable;
+
+    private ObjectiveDtoBuilder() {
+    }
+
+    public static ObjectiveDtoBuilder builder() {
+        return new ObjectiveDtoBuilder();
+    }
+
+    public ObjectiveDtoBuilder withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withVersion(int version) {
+        this.version = version;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withTeamId(Long teamId) {
+        this.teamId = teamId;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withQuarterId(Long quarterId) {
+        this.quarterId = quarterId;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withQuarterLabel(String quarterLabel) {
+        this.quarterLabel = quarterLabel;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withState(State state) {
+        this.state = state;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withCreatedOn(LocalDateTime createdOn) {
+        this.createdOn = createdOn;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withModifiedOn(LocalDateTime modifiedOn) {
+        this.modifiedOn = modifiedOn;
+        return this;
+    }
+
+    public ObjectiveDtoBuilder withWriteable(boolean writeable) {
+        this.writeable = writeable;
+        return this;
+    }
+
+    public ObjectiveDto build() {
+        return new ObjectiveDto(id, version, title, teamId, quarterId, quarterLabel, description, state, createdOn,
+                modifiedOn, writeable);
+    }
+
+}

--- a/frontend/src/app/components/objective/ObjectiveMenuAfterActions.ts
+++ b/frontend/src/app/components/objective/ObjectiveMenuAfterActions.ts
@@ -4,10 +4,12 @@ import { Completed } from '../../shared/types/model/Completed';
 import { ObjectiveService } from '../../services/objective.service';
 import { RefreshDataService } from '../../services/refresh-data.service';
 import { ObjectiveMin } from '../../shared/types/model/ObjectiveMin';
+import { CompletedService } from '../../services/completed.servce';
 
 export class ObjectiveMenuAfterActions {
   constructor(
     private readonly objectiveService: ObjectiveService,
+    private readonly completedService: CompletedService,
     private readonly refreshDataService: RefreshDataService,
   ) {}
 
@@ -21,7 +23,7 @@ export class ObjectiveMenuAfterActions {
         comment: result.comment,
       };
       this.objectiveService.updateObjective(objective).subscribe(() => {
-        this.objectiveService.createCompleted(completed).subscribe(() => {
+        this.completedService.createCompleted(completed).subscribe(() => {
           this.refreshDataService.markDataRefresh();
         });
       });
@@ -50,7 +52,7 @@ export class ObjectiveMenuAfterActions {
     this.objectiveService.getFullObjective(objectiveMin.id).subscribe((objective: Objective) => {
       objective.state = 'ONGOING' as State;
       this.objectiveService.updateObjective(objective).subscribe(() => {
-        this.objectiveService.deleteCompleted(objective.id).subscribe(() => {
+        this.completedService.deleteCompleted(objective.id).subscribe(() => {
           this.refreshDataService.markDataRefresh();
         });
       });

--- a/frontend/src/app/components/objective/objective.component.spec.ts
+++ b/frontend/src/app/components/objective/objective.component.spec.ts
@@ -21,6 +21,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import * as de from '../../../assets/i18n/de.json';
 import { TranslateTestingModule } from 'ngx-translate-testing';
 import { ObjectiveService } from '../../services/objective.service';
+import { CompletedService } from '../../services/completed.servce';
 
 const overviewServiceMock = {
   getObjectiveWithKeyresults: jest.fn(),
@@ -28,6 +29,11 @@ const overviewServiceMock = {
 
 const objectiveServiceMock = {
   getFullObjective: jest.fn(),
+};
+
+const completedServiceMock = {
+  createCompleted: jest.fn(),
+  deleteCompleted: jest.fn(),
 };
 
 describe('ObjectiveColumnComponent', () => {
@@ -54,6 +60,7 @@ describe('ObjectiveColumnComponent', () => {
       providers: [
         { provide: OverviewService, useValue: overviewServiceMock },
         { provide: ObjectiveService, useValue: objectiveServiceMock },
+        { provide: CompletedService, useValue: completedServiceMock },
       ],
     }).compileComponents();
 

--- a/frontend/src/app/services/completed.servce.ts
+++ b/frontend/src/app/services/completed.servce.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Completed } from '../shared/types/model/Completed';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CompletedService {
+  constructor(private httpClient: HttpClient) {}
+
+  createCompleted(completed: Completed): Observable<Completed> {
+    return this.httpClient.post<Completed>('/api/v2/completed', completed);
+  }
+
+  deleteCompleted(objectiveId: number): Observable<Completed> {
+    return this.httpClient.delete<Completed>('/api/v2/completed/' + objectiveId);
+  }
+}

--- a/frontend/src/app/services/completed.service.spec.ts
+++ b/frontend/src/app/services/completed.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CompletedService } from './completed.servce';
+
+describe('CompletedService', () => {
+  let service: CompletedService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(CompletedService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/objective-menu-actions.service.ts
+++ b/frontend/src/app/services/objective-menu-actions.service.ts
@@ -6,9 +6,9 @@ import { State } from '../shared/types/enums/State';
 import { ObjectiveMenuAfterActions } from '../components/objective/ObjectiveMenuAfterActions';
 import { ObjectiveService } from './objective.service';
 import { RefreshDataService } from './refresh-data.service';
-import { Objective } from '../shared/types/model/Objective';
 import { ObjectiveMenuActions } from '../components/objective/ObjectiveMenuActions';
 import { GJ_REGEX_PATTERN } from '../shared/constantLibary';
+import { CompletedService } from './completed.servce';
 
 export type ObjectiveMenuAction = () => MatDialogRef<any>;
 export type ObjectiveMenuAfterAction = (objective: ObjectiveMin, dialogResult: any) => any;
@@ -28,9 +28,10 @@ export class ObjectiveMenuActionsService {
   constructor(
     dialogService: DialogService,
     objectiveService: ObjectiveService,
+    completedService: CompletedService,
     refreshDataService: RefreshDataService,
   ) {
-    this.afterActions = new ObjectiveMenuAfterActions(objectiveService, refreshDataService);
+    this.afterActions = new ObjectiveMenuAfterActions(objectiveService, completedService, refreshDataService);
     this.actions = new ObjectiveMenuActions(dialogService, refreshDataService, this.afterActions);
   }
 

--- a/frontend/src/app/services/objective.service.ts
+++ b/frontend/src/app/services/objective.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Objective } from '../shared/types/model/Objective';
 import { Observable } from 'rxjs';
-import { Completed } from '../shared/types/model/Completed';
 
 @Injectable({
   providedIn: 'root',
@@ -28,13 +27,5 @@ export class ObjectiveService {
 
   duplicateObjective(objectiveId: number, objectiveDTO: any): Observable<Objective> {
     return this.httpClient.post<Objective>(`/api/v2/objectives/${objectiveId}`, objectiveDTO);
-  }
-
-  createCompleted(completed: Completed): Observable<Completed> {
-    return this.httpClient.post<Completed>('/api/v2/completed', completed);
-  }
-
-  deleteCompleted(objectiveId: number): Observable<Completed> {
-    return this.httpClient.delete<Completed>('/api/v2/completed/' + objectiveId);
   }
 }


### PR DESCRIPTION
**Backend** ✅

- CompletedDto sollte ein `ObjectiveDto` und nicht ein `Objective` haben. Dies ist nun gefixt.
- Daraus ergibt sich das Problem, dass die Tests ziemlich unschön werden, weil man ein ObjectiveDto und nicht mehr ein Objective erstellen muss. ObjectiveDto ist ein Record und hat keinen Builder. Dies habe ich nun geändert und für Testing in `ch.puzzle.okr.test.dto.builder` zwei Builder `CompletedDtoBuilder` und `ObjectiveDtoBuilder`  implementiert. 
- Zusätzlich habe ich ein cleanup der bestehenden Completed Tests gemacht und die neuen Builder verwendet.

**TODOs im Backend für die Lernenden** ❌

- in `CompletedController` gibt noch kein Endpoint fürs Laden von bestehenden Completed
- Nicht jedes Objective muss ein Complete haben. Daher sollte der neue Endpoint ein `404` zurückgeben und ein `200` im Erfolgsfall.  
- IT Tests für neuen Endpoint in  `CompletedControllerIT` 


**Frontend** ✅

- all Service calls mit dem Format `/api/v2/completed/`  vom ObjectiveService in einen neuen CompletedService zügeln. Es macht Sinn, diese zu trennen, denn es sind verschiedene Dinge (sind im backend in der DB und in den Services und Controllers auch getrennt)
- Tests sind gefixt


**TODOs im Frontend für die Lernenden** ❌

- aktueller Stand bzgl. Completed im Frontend: Completed wir nur verwendet fürs Erstellen und Löschen. Den aktuellen Complete Status für ein Objective kenn das Frontend nicht. Das Rendering von completed Objectives basiert auf dem State im  Objective.
- Im Frontend muss man sich die Daten vom Frontend über den noch nicht existierenden `get` Endpoint im CompletedController. Es muss sauber behandelt werden, dass für Objectives die kein Completed haben ein `404` zurückkommt.
- (jest) Tests und Cypress Tests