### PR TITLE
Improve Renovate Configuration

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -5,6 +5,8 @@ Release Notes Puzzle OKR
 Version     Neuerungen
 -----------------------------------------------------------------------------
 
+unreleased  - Erweiterung #1481: Dependency-Updates werden neu gruppiert und teilweise automatisch gemergt
+
 3.2.0        - Fehlerbehebung #1432: Eine Action kann nun wieder als abgeschlossen markiert werden.
 
              - Wartung: Updates diverser Dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     ":rebaseStalePrs",
-    ":automergePatch",
     "group:monorepos"
   ],
   "schedule" : [

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    ":rebaseStalePrs",
+    ":automergePatch",
+    "group:monorepos"
+  ],
+  "schedule" : [
+    "* 1-5 * * 1-5"
+  ],
+  "automergeSchedule": [
+    "* 5-7 * * 1-5"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
+  ],
+  "automergeType": "pr",
+  "timezone": "Europe/Zurich"
 }


### PR DESCRIPTION
With this renovate should:
 - only create PRs on weekdays between 01:00 and 05:00
 - only automerge PRs on weekdays between 05:00 and 07:00
 - automerge minor and patch versions of dev dependencies
 - group Angular upgrades into single PRs


Config has been locally tested if it is valid, against this command:
```shell
LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset
```

This cannot guarantee that the behavior is correct though.