### PR TITLE
Improve handling of flaky tests

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -10,5 +10,11 @@ export default defineConfig({
   },
   env: {
     LOGIN_URL: 'http://localhost:8544'
-  }
+  },
+  retries: {
+    // Configure retry attempts for `cypress run`
+    runMode: 2,
+    // Configure retry attempts for `cypress open`
+    openMode: 0,
+  },
 });


### PR DESCRIPTION
Cypress tests should now automatically be retried up to 2 times. This only happens if the tests are executed with ` cypress run`, which leaves any local development with ` cypress open` unaffected. 

This should hopefully reduce the times a workflow fails because of a flaky test and may close #1339 (at least for the time being). 

See it in action [here](https://github.com/puzzle/okr/actions/runs/14517340147/job/40730226545?pr=1507#step:6:145).
```shell
as "BL"
      ✓ should have correct roles on user "Esha" (2798ms)
      ✓ should not be able to edit team "LoremIpsum" (2574ms)
      ✓ should be able to edit team "/BBT" and edit its name (3654ms)
      ✓ should add members to team "/BBT" (3472ms)
      ✓ should change role of "Findus Peterson" to team "Admin" (3299ms)
      (Attempt 1 of 3) should not be able to add "Findus Peterson" to further teams
      ✓ should not be able to add "Findus Peterson" to further teams (3104ms)
      ✓ should remove "BBT" membership from "Findus Peterson" (3127ms)
      ✓ should remove added memberships from "Esha" (3389ms)
      ✓ should not be able to edit okr champion state of user "Esha" (2621ms)
```