### PR TITLE
fix: Scale down DB pool size for staging from 3 to 2 #1587

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -14,7 +14,7 @@ hibernate.connection.username=user
 hibernate.connection.password=pwd
 hibernate.multi-tenancy=SCHEMA
 # hikari
-hibernate.hikari.maximumPoolSize=10
+hibernate.hikari.maximumPoolSize=5
 
 
 # TENANT Configuration

--- a/backend/src/main/resources/application-staging.properties
+++ b/backend/src/main/resources/application-staging.properties
@@ -11,7 +11,7 @@ hibernate.connection.username=user
 hibernate.connection.password=pwd
 hibernate.multi-tenancy=SCHEMA
 # hikari
-hibernate.hikari.maximumPoolSize=3
+hibernate.hikari.maximumPoolSize=2
 
 
 # TENANT Configuration


### PR DESCRIPTION
Scale down pool size because staging has at most 1-2 people using it. This makes `2*5 + 2*3 + 2*2 = 20` connections at most over all stages.